### PR TITLE
ppx_sexp_conv >= v0.11 has a runtime dependency

### DIFF
--- a/yaml.opam
+++ b/yaml.opam
@@ -11,7 +11,7 @@ available: [ ocaml-version >= "4.03.0"]
 depends: [
   "jbuilder" {build & >="1.0+beta17"}
   "ctypes" {>="0.12.0"}
-  "ppx_sexp_conv" {build & >="v0.9.0"}
+  "ppx_sexp_conv" {>="v0.9.0"}
   "sexplib"
   "rresult"
   "fmt"


### PR DESCRIPTION
See [this comment](https://github.com/ocaml/opam-repository/pull/11901#issuecomment-386567425) for details