### PR TITLE
Switch from Cstubs.FOREIGN to Ctypes.FOREIGN to eliminate cstubs runtime dependency

### DIFF
--- a/ffi/bindings/yaml_bindings.ml
+++ b/ffi/bindings/yaml_bindings.ml
@@ -14,7 +14,7 @@
 
 module T = Yaml_types.M
 
-module M(F: Cstubs.FOREIGN) =
+module M(F: Ctypes.FOREIGN) =
 struct
   let foreign = F.foreign
 

--- a/types/bindings/yaml_bindings_types.ml
+++ b/types/bindings/yaml_bindings_types.ml
@@ -51,7 +51,7 @@ module Event_type = struct
            | `Sequence_end | `Mapping_start | `Mapping_end | `E of int64 ] [@@deriving sexp]
 end
  
-module M(F : Cstubs.Types.TYPE) =
+module M(F : Ctypes.TYPE) =
 struct
 
   let yaml_char_t = F.uchar

--- a/types/bindings/yaml_bindings_types.mli
+++ b/types/bindings/yaml_bindings_types.mli
@@ -49,7 +49,7 @@ module Event_type : sig
            | `Sequence_end | `Mapping_start | `Mapping_end | `E of int64 ] [@@deriving sexp]
 end
  
-module M(F : Cstubs.Types.TYPE) : sig
+module M(F : Ctypes.TYPE) : sig
   val encoding_t : Encoding.t F.typ
   val error_t : Error.t F.typ
   val scalar_style_t : Scalar_style.t F.typ


### PR DESCRIPTION
See https://github.com/mirage/mirage/issues/901