### PR TITLE
Use dune.configurator

### DIFF
--- a/config/discover.ml
+++ b/config/discover.ml
@@ -1,18 +1,18 @@
-module C = Configurator
+module C = Configurator.V1
+
+let ocamlopt_lines c =
+  let cflags = C.ocaml_config_var_exn c "ocamlopt_cflags" in
+  C.Flags.extract_blank_separated_words cflags
+
+let ppc64_lines c =
+  let arch = C.ocaml_config_var_exn c "architecture" in
+  let model = C.ocaml_config_var_exn c "model" in
+  match arch, model with
+  | "power", "ppc64le" -> ["-mcmodel=small"]
+  | _ -> []
 
 let () =
   C.main ~name:"yaml" (fun c ->
-    let cflags = C.ocaml_config_var_exn c "ocamlopt_cflags" in
-    let arch = C.ocaml_config_var_exn c "architecture" in
-    let model = C.ocaml_config_var_exn c "model" in
-    let cflags =
-      match arch,model with
-      |"power","ppc64le" -> cflags ^ " -mcmodel=small"
-      |_ -> cflags in
-    let fout = open_out "cflags" in
-    String.iter (fun c ->
-      let c = if c = ' ' then '\n' else c in
-      output_char fout c
-    ) cflags;
-    close_out fout
+    let lines = ocamlopt_lines c @ ppc64_lines c in
+    C.Flags.write_lines "cflags" lines
   )

--- a/config/dune
+++ b/config/dune
@@ -1,6 +1,6 @@
 (executable
  (name discover)
- (libraries configurator))
+ (libraries dune.configurator))
 
 (rule
  (targets cflags)

--- a/yaml.opam
+++ b/yaml.opam
@@ -10,7 +10,6 @@ tags: ["org:mirage" "org:ocamllabs"]
 available: [ ocaml-version >= "4.03.0"]
 depends: [
   "dune" {build}
-  "configurator"
   "ctypes" {>="0.12.0"}
   "ppx_sexp_conv" {>="v0.9.0"}
   "sexplib"


### PR DESCRIPTION
This uses `extract_blank_separated_words` instead of splitting by hand.

(Closes #13, supersedes #14, cc @pascutto @g2p)