### PR TITLE
Handle quoted scalars

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Default behaviour, for if core.autocrlf isn't set
+* text=auto
+
+.azure-pipelines.sh text eol=lf

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## vX.Y.Z (dd/mm/yyyy)
+
+* Represent quoted scalars as strings in Json encoding (@rizo, fixes #20).
+* Expose more detailed scalar information in `Yaml.yaml` (@rizo).
+* Add `Yaml.equal` (@rizo)
+
 ## v1.0.0 (17/02/2019)
 * Support parsing of canonical Yaml null, float and bool
   values (@avsm, fixes #15 #16).

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -50,17 +50,20 @@ type value =
   | `O of (string * value) list
 ] [@@deriving sexp]
 
-type anchor_string = {
+type scalar = {
   anchor: string option;
+  tag: string option;
   value: string;
+  plain_implicit: bool;
   quoted_implicit: bool;
+  style: scalar_style
 } [@@deriving sexp]
 
 type yaml =
-  [ `String of anchor_string
+  [ `Scalar of scalar
   | `Alias of string
   | `A of yaml list
-  | `O of (anchor_string * yaml) list
+  | `O of (scalar * yaml) list
 ] [@@deriving sexp]
 
 type 'a res = ('a, Rresult.R.msg) Result.result

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -16,7 +16,7 @@ open Sexplib.Conv
 
 type version = [
  | `V1_0
- | `V1_1 
+ | `V1_1
 ] [@@deriving sexp]
 
 type encoding = [
@@ -53,6 +53,7 @@ type value =
 type anchor_string = {
   anchor: string option;
   value: string;
+  quoted_implicit: bool;
 } [@@deriving sexp]
 
 type yaml =

--- a/lib/yaml.ml
+++ b/lib/yaml.ml
@@ -194,7 +194,7 @@ let rec equal v1 v2 =
   match v1, v2 with
   | `Null, `Null -> true
   | `Bool x1, `Bool x2 -> ((=) : bool -> bool -> bool) x1 x2
-  | `Float x1, `Float x2 -> Float.equal x1 x2
+  | `Float x1, `Float x2 -> ((=) : float -> float -> bool) x1 x2
   | `String x1, `String x2 -> String.equal x1 x2
   | `A xs1, `A xs2 -> List.for_all2 equal xs1 xs2
   | `O xs1, `O xs2 ->

--- a/lib/yaml.ml
+++ b/lib/yaml.ml
@@ -184,3 +184,16 @@ let pp ppf s =
   match to_string s with
   | Ok s -> Format.pp_print_string ppf s
   | Error (`Msg m) -> Format.pp_print_string ppf (Printf.sprintf "(error (%s))" m)
+
+let rec equal v1 v2 =
+  match v1, v2 with
+  | `Null, `Null -> true
+  | `Bool x1, `Bool x2 -> ((=) : bool -> bool -> bool) x1 x2
+  | `Float x1, `Float x2 -> Float.equal x1 x2
+  | `String x1, `String x2 -> String.equal x1 x2
+  | `A xs1, `A xs2 -> List.for_all2 equal xs1 xs2
+  | `O xs1, `O xs2 ->
+      List.for_all2 (fun (k1, v1) (k2, v2) ->
+        String.equal k1 k2 && equal v1 v2) xs1 xs2
+  | _ -> false
+

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -132,6 +132,9 @@ val to_string_exn : ?len:int -> ?encoding:encoding -> ?scalar_style:scalar_style
 val pp : Format.formatter -> value -> unit
 (** [pp ppf s] will output the Yaml value [s] to the formatter [ppf]. *)
 
+val equal : value -> value -> bool
+(** [equal v1 v2] is [true] iff [v1] and [v2] are equal. *)
+
 (** {3 Yaml-specific functions} *)
 
 val yaml_of_string : string -> yaml res

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -16,7 +16,7 @@
 
   It is based on a binding to {{:http://pyyaml.org/wiki/LibYAML:}libyaml}
   which covers the generation and parsing processes.
- 
+
   Most simple use cases can simply use the {!of_string} and {!to_string}
   functions, which are compatible with the {!Ezjsonm} types.  This means
   that you can convert between JSON and Yaml format easily.
@@ -57,6 +57,7 @@ type yaml =
 and anchor_string = {
   anchor: string option;
   value: string;
+  quoted_implicit: bool;
 } [@@deriving sexp]
 (** [anchor_string] holds a possible Yaml anchor, and the string [value] *)
 

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -43,10 +43,10 @@ type value =
   most simple uses of Yaml can be interchanged with JSON. *)
 
 type yaml =
-  [ `String of anchor_string
+  [ `Scalar of scalar
   | `Alias of string
   | `A of yaml list
-  | `O of (anchor_string * yaml) list
+  | `O of (scalar * yaml) list
 ]
 (** [yaml] is the representation of a Yaml document that
   preserves alias information and other Yaml-specific metadata
@@ -54,22 +54,24 @@ type yaml =
   to convert untrusted Yaml with aliases into JSON due to the
   risk of denial-of-service via a
   {{:https://en.wikipedia.org/wiki/Billion_laughs_attack}Billion Laughs attack}. *)
-and anchor_string = {
+
+and scalar = {
   anchor: string option;
+  tag: string option;
   value: string;
+  plain_implicit: bool;
   quoted_implicit: bool;
+  style: scalar_style
 } [@@deriving sexp]
-(** [anchor_string] holds a possible Yaml anchor, and the string [value] *)
+(** [scalar] is the description of a Yaml scalar.
 
-type version = [ `V1_0 | `V1_1 ] [@@deriving sexp]
-(** Version of the YAML spec of a document.
-  Refer to the {{:http://www.yaml.org/spec/1.2/spec.html}Yaml specification}
-  for details of the differences between versions. *)
+   Scalar values are represented as strings. A scalar can optionally have an
+   [anchor] and a [tag]. The flow style of the scalar is defined by the [style]
+   field. If [plain_implicit] is [true], the tag is optional for the plain
+   style. If [quoted_implicit] is [true], the tag is optional for any non-plain
+   style. *)
 
-type encoding = [ `Any | `Utf16be | `Utf16le | `Utf8 ] [@@deriving sexp]
-(** Document encoding. The recommended format is [Utf8]. *)
-
-type scalar_style = [
+and scalar_style = [
   | `Any
   | `Plain
   | `Single_quoted
@@ -82,6 +84,14 @@ type scalar_style = [
   and expressive power.
   The {{:http://www.yaml.org/spec/1.2/spec.html#id2786942:}Yaml spec section 7.3}
   has more details. *)
+
+type version = [ `V1_0 | `V1_1 ] [@@deriving sexp]
+(** Version of the YAML spec of a document.
+  Refer to the {{:http://www.yaml.org/spec/1.2/spec.html}Yaml specification}
+  for details of the differences between versions. *)
+
+type encoding = [ `Any | `Utf16be | `Utf16le | `Utf8 ] [@@deriving sexp]
+(** Document encoding. The recommended format is [Utf8]. *)
 
 type layout_style = [
   | `Any
@@ -206,13 +216,7 @@ module Stream : sig
           ; style: layout_style }
       | Mapping_end
       | Stream_end
-      | Scalar of
-          { anchor: string option
-          ; tag: string option
-          ; value: string
-          ; plain_implicit: bool
-          ; quoted_implicit: bool
-          ; style: scalar_style }
+      | Scalar of scalar
       | Sequence_start of
           { anchor: string option
           ; tag: string option
@@ -255,8 +259,7 @@ module Stream : sig
 
   val document_end : ?implicit:bool -> emitter -> unit res
 
-  val scalar : ?plain_implicit:bool -> ?quoted_implicit:bool -> ?anchor:string ->
-    ?tag:string -> ?style:scalar_style -> emitter -> string -> unit res
+  val scalar : scalar -> emitter -> unit res
 
   val alias : emitter -> string -> unit res
 

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -42,12 +42,30 @@ let emit =
 let version =
   [ "version", `Quick, (fun () -> Alcotest.check t "version" (Ok ()) (Test_version.v ())) ]
 
+let yaml_equal =
+  let test name expected v1 v2 =
+    (name, `Quick, Alcotest.(fun () ->
+      check bool name expected (Yaml.equal v1 v2)));
+  in [
+    test "two null equal" true `Null `Null;
+    test "two floats equal" true (`Float 2.718) (`Float 2.718);
+    test "two floats not equal" false (`Float 2.718) (`Float 3.141);
+    test "two bools equal" true (`Bool true) (`Bool true);
+    test "two strings equal" true (`String "foo") (`String "foo");
+    test "two strings not equal" false (`String "foo") (`String "bar");
+    test "two arrays equal" true (`A [`String "foo"; `Null; `Bool true]) (`A [`String "foo"; `Null; `Bool true]);
+    test "two arrays not equal" false (`A [`Null]) (`A [`String "foo"; `Null; `Bool true]);
+    test "two objects equal" true (`O ["a", `A [`String "foo"; `Null]]) (`O ["a", `A [`String "foo"; `Null]]);
+    test "different types not equal" false (`Float 2.718) (`O ["k1", `String "foo"; "k2", `Null; "k3", `Bool true]);
+  ]
+
 let tests = [
     "parse_event_test_set", parse_event_test_set all_files;
     "parse_of_string", parse_of_string all_simple_files;
     "reflect", reflect all_files;
     "emit", emit;
-    "version", version
+    "version", version;
+    "yaml_equal", yaml_equal;
   ]
 
 (* Run it *)

--- a/tests/test_emit.ml
+++ b/tests/test_emit.ml
@@ -17,22 +17,26 @@ open R.Infix
 
 module S = Yaml.Stream
 
+let scalar ?anchor ?tag ?(plain_implicit=true) ?(quoted_implicit=false)
+    ?(style=`Plain) value : Yaml.scalar =
+  { anchor; tag; plain_implicit; quoted_implicit; style; value }
+
 let v () =
   S.emitter () >>= fun t ->
   S.stream_start t `Utf8 >>= fun () ->
   S.document_start t >>= fun () ->
   S.sequence_start t >>= fun () ->
-  S.scalar ~tag:"sup" t "foo1" >>= fun () ->
+  S.scalar (scalar ~tag:"sup" "foo1") t >>= fun () ->
   S.mapping_start ~tag:"xx" t >>= fun () ->
-  S.scalar ~tag:"sup" t "foo2" >>= fun () ->
-  S.scalar ~tag:"sup" t "bar3" >>= fun () ->
+  S.scalar (scalar ~tag:"sup" "foo2") t >>= fun () ->
+  S.scalar (scalar ~tag:"sup" "bar3") t >>= fun () ->
   S.mapping_end t >>= fun () ->
   S.mapping_start t >>= fun () ->
-  S.scalar ~tag:"bar" t "foo4" >>= fun () ->
+  S.scalar (scalar ~tag:"bar" "foo4") t >>= fun () ->
   S.sequence_start t >>= fun () ->
-  S.scalar t ~tag:"bar" "foo5" >>= fun () ->
-  S.scalar t ~tag:"bar2" "foo6" >>= fun () ->
-  S.scalar t ~tag:"bar3" "foo7" >>= fun () ->
+  S.scalar (scalar ~tag:"bar" "foo5") t >>= fun () ->
+  S.scalar (scalar ~tag:"bar2" "foo6") t >>= fun () ->
+  S.scalar (scalar ~tag:"bar3" "foo7") t >>= fun () ->
   S.sequence_end t >>= fun () ->
   S.mapping_end t >>= fun () ->
   S.sequence_end t >>= fun () ->
@@ -42,4 +46,4 @@ let v () =
   let r = S.emitter_buf t in
   print_endline (Bytes.to_string r);
   Ok ()
-  
+

--- a/yaml.opam
+++ b/yaml.opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {build & >="1.3"}
   "ctypes" {>= "0.12.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
-  "sexplib"
+  "sexplib0" {< "v0.12"}
   "rresult"
   "fmt"
   "logs"

--- a/yaml.opam
+++ b/yaml.opam
@@ -1,6 +1,6 @@
 opam-version: "2.0"
 maintainer: "Anil Madhavapeddy <anil@recoil.org>"
-authors: "Anil Madhavapeddy <anil@recoil.org>"
+authors: ["Anil Madhavapeddy <anil@recoil.org>" "Rizo Isrof <rizo@odis.io>"]
 license: "ISC"
 tags: ["org:mirage" "org:ocamllabs"]
 homepage: "https://github.com/avsm/ocaml-yaml"
@@ -11,7 +11,7 @@ depends: [
   "dune" {build & >="1.3"}
   "ctypes" {>= "0.12.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
-  "sexplib"
+  "sexplib0" {< "v0.12"}
   "rresult"
   "fmt"
   "logs"
@@ -31,7 +31,7 @@ synopsis: "Parse and generate YAML 1.1 files"
 description: """
 This is an OCaml library to parse and generate the YAML file
 format.  It is intended to interoperable with the [Ezjsonm](https://github.com/mirage/ezjsonm)
-JSON handling library, if the simple common subset of Yaml 
+JSON handling library, if the simple common subset of Yaml
 is used.  Anchors and other advanced Yaml features are not
 implemented in the JSON compatibility layer.
 

--- a/yaml.opam
+++ b/yaml.opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {build & >="1.3"}
   "ctypes" {>= "0.12.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
-  "sexplib0" {< "v0.12"}
+  "sexplib"
   "rresult"
   "fmt"
   "logs"


### PR DESCRIPTION
Fixes https://github.com/avsm/ocaml-yaml/issues/20.

I tried to find some information on implicit scalar quoting, but unfortunately it's not well documented. The only mention the spec has is for quoted implicit keys (see [Double-Quoted Style](https://yaml.org/spec/1.2/spec.html#id2787109) and [Single-Quoted Style](https://yaml.org/spec/1.2/spec.html#id2788097)). The only other explanation I found helpful was the "When not to use Plain Scalars" section [here](http://blogs.perl.org/users/tinita/2018/03/strings-in-yaml---to-quote-or-not-to-quote.html) (see the paragraph in the end about strings that would be resolved as a special types).

My conclusion from this is that quoted scalars must be treated as strings, which is what this patch does. I also tested a couple of other parsers and it seems they all do this.

If this looks good, I'll add some tests to cover the edge cases.