### PR TITLE
prepare 2.0.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
-## vX.Y.Z (dd/mm/yyyy)
+## v2.0.0 (20/02/2019)
 
-* Represent quoted scalars as strings in Json encoding (@rizo, fixes #20).
-* Expose more detailed scalar information in `Yaml.yaml` (@rizo).
-* Add `Yaml.equal` (@rizo)
+* Represent quoted scalars as strings in Json encoding (#22 @rizo, fixes #20).
+* Expose more detailed scalar information in `Yaml.yaml` (#22 @rizo).
+* Add `Yaml.equal` (#22 @rizo)
 
 ## v1.0.0 (17/02/2019)
 * Support parsing of canonical Yaml null, float and bool

--- a/dune-project
+++ b/dune-project
@@ -1,1 +1,2 @@
 (lang dune 1.3)
+(name yaml)

--- a/yaml.opam
+++ b/yaml.opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {build & >="1.3"}
   "ctypes" {>= "0.12.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
-  "sexplib0" {< "v0.12"}
+  "sexplib0" 
   "rresult"
   "fmt"
   "logs"

--- a/yaml.opam
+++ b/yaml.opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {build & >="1.3"}
   "ctypes" {>= "0.12.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
-  "sexplib0" 
+  "sexplib"
   "rresult"
   "fmt"
   "logs"


### PR DESCRIPTION
the sexplib constraint seems to work with v0.12, so relax it
again now that opam-repository has been fixed