### PR TITLE
On parse error, use parser->problem* struct information in exception

### DIFF
--- a/lib/stream.ml
+++ b/lib/stream.ml
@@ -221,9 +221,17 @@ let parser buf =
 let do_parse {p;event} =
   let open Ctypes in
   let r = B.parser_parse p event in
+  let describe_problem () =
+    match Ctypes.(getf !@p T.Parser.problem) with
+    | None -> "(no problem description)"
+    | Some s ->
+      let pv = Ctypes.(getf !@p T.Parser.problem_value) in
+      let po = Ctypes.(getf !@p T.Parser.problem_offset) in
+      s ^ " character " ^ (string_of_int pv) ^ " position " ^ (Unsigned.Size_t.to_string po)
+  in
   match r with
   | 1 -> Event.of_ffi (!@ event) |> R.ok
-  | n -> R.error_msg ("error calling parser: " ^ string_of_int n)
+  | n -> R.error_msg ("error calling parser: " ^ (describe_problem ()) ^ " returned: " ^ string_of_int n)
 
 type emitter = {
   e: T.Emitter.t Ctypes.structure Ctypes.ptr;

--- a/types/bindings/yaml_bindings_types.ml
+++ b/types/bindings/yaml_bindings_types.ml
@@ -282,6 +282,9 @@ struct
     let t : t typ = F.structure "yaml_parser_s"
     (* TODO *)
     let error = F.(field t "error" error_t)
+    let problem = F.(field t "problem" string_opt)
+    let problem_offset = F.(field t "problem_offset" size_t)
+    let problem_value = F.(field t "problem_value" int)
     let () = F.seal t
   end
 

--- a/types/bindings/yaml_bindings_types.mli
+++ b/types/bindings/yaml_bindings_types.mli
@@ -193,6 +193,9 @@ module M(F : Ctypes.TYPE) : sig
   module Parser : sig
     type t
     val t : t typ
+    val problem : (t, string option) field
+    val problem_offset : (t, Unsigned.size_t) field
+    val problem_value : (t, int) field
   end
 
   module Emitter : sig


### PR DESCRIPTION
If there is problem with parsing, the libyaml C function returns 0, as well as sets `struct parser_s` fields: `problem`, `problem_offset`, `problem_value` to problem description, byte offset in source data, and problematic byte value respectively. This PR passes these three information to the message returned in `Result.Error(msg)`. 