### PR TITLE
Manage buffer with yaml in OCaml part of ocaml-yaml

### DIFF
--- a/ffi/bindings/yaml_bindings.ml
+++ b/ffi/bindings/yaml_bindings.ml
@@ -40,7 +40,7 @@ struct
     foreign "yaml_parser_delete" C.(ptr T.Parser.t @-> returning void)
 
   let parser_set_input_string =
-    foreign "yaml_parser_set_input_string" C.(ptr T.Parser.t @-> string @-> size_t @-> returning void)
+    foreign "yaml_parser_set_input_string" C.(ptr T.Parser.t @-> ptr char @-> size_t @-> returning void)
 
   let parser_parse =
     foreign "yaml_parser_parse" C.(ptr T.Parser.t @-> ptr T.Event.t @-> returning int)

--- a/lib/stream.ml
+++ b/lib/stream.ml
@@ -205,15 +205,17 @@ let get_version () =
 type parser = {
   p: T.Parser.t Ctypes.structure Ctypes.ptr;
   event: T.Event.t Ctypes.structure Ctypes.ptr;
-  buf: string;
+  buf: char Ctypes_static.carray;
 }
 
-let parser buf =
+let parser str =
   let p = Ctypes.(allocate_n T.Parser.t ~count:1) in
   let event = Ctypes.(allocate_n T.Event.t ~count:1) in
   let r = B.parser_init p in
-  let len = String.length buf |> Unsigned.Size_t.of_int in
-  B.parser_set_input_string p buf len;
+  let buf = Ctypes.CArray.of_string str in
+  let buf_ptr = Ctypes.CArray.start buf in
+  let len = String.length str |> Unsigned.Size_t.of_int in
+  B.parser_set_input_string p buf_ptr len;
   match r with
   | 1 -> R.ok {buf; p;event}
   | n -> R.error_msg ("error initialising parser: " ^ string_of_int n)


### PR DESCRIPTION
This fixes #17 and #33 which result from a bug in passing input buffer to yaml parser. 
When a string with yaml text is passed to
`yaml_parser_set_input_string`, it only stores a pointer to it (not a
copy). The temporary buffer, created by the FFI from string on calling this
function is freed, and later overwritten - before being parsed by YAML parser. The corrupted input buffer makes the parsing fail.

This changes the signature of yaml_parser_set_input_string to accept char ptr,
and the char array is stored in parser type structure as long as is needed for
parsing.

There is another PR with a test containing a large yaml file #30  