### PR TITLE
to_string{_exn,}: add ?string_style argument

### DIFF
--- a/lib/yaml.ml
+++ b/lib/yaml.ml
@@ -62,13 +62,13 @@ let of_json (v:value) =
   | r -> Ok r
   | exception (Failure msg) -> R.error_msg msg
 
-let to_string ?len ?(encoding=`Utf8) ?scalar_style ?layout_style (v:value) =
+let to_string ?len ?(encoding=`Utf8) ?string_style ?scalar_style ?layout_style (v:value) =
   emitter ?len () >>= fun t ->
   stream_start t encoding >>= fun () ->
   document_start t >>= fun () ->
   let rec iter = function
      |`Null -> Stream.scalar (scalar "") t
-     |`String s -> Stream.scalar (scalar ?style:scalar_style s) t
+     |`String s -> Stream.scalar (scalar ?style:string_style s) t
      |`Float s -> Stream.scalar (scalar (Printf.sprintf "%.16g" s)) t
      (* NOTE: Printf format on the line above taken from the jsonm library *)
      |`Bool s -> Stream.scalar (scalar (string_of_bool s)) t
@@ -91,8 +91,8 @@ let to_string ?len ?(encoding=`Utf8) ?scalar_style ?layout_style (v:value) =
   let r = Stream.emitter_buf t in
   Ok (Bytes.to_string r)
 
-let to_string_exn ?len ?encoding ?scalar_style ?layout_style s =
-  match to_string ?len ?encoding ?scalar_style ?layout_style s with
+let to_string_exn ?len ?encoding ?string_style ?scalar_style ?layout_style s =
+  match to_string ?len ?encoding ?string_style ?scalar_style ?layout_style s with
   | Ok s -> s
   | Error (`Msg m) -> raise (Invalid_argument m)
 

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -126,7 +126,9 @@ val of_string_exn : string -> value
 (** [of_string_exn s] acts as {!of_string}, but raises {!Invalid_argument}
   if there is an error. *)
 
-val to_string : ?len:int -> ?encoding:encoding -> ?scalar_style:scalar_style ->
+val to_string : ?len:int -> ?encoding:encoding ->
+  ?string_style:scalar_style ->
+  ?scalar_style:scalar_style ->
   ?layout_style:layout_style -> value -> string res
 (** [to_string v] converts the JSON value to a Yaml string representation.
    The [encoding], [scalar_style] and [layout_style] control the various
@@ -134,7 +136,9 @@ val to_string : ?len:int -> ?encoding:encoding -> ?scalar_style:scalar_style ->
    The current implementation uses a non-resizable internal string buffer of
    64KB, which can be increased via [len].  *)
 
-val to_string_exn : ?len:int -> ?encoding:encoding -> ?scalar_style:scalar_style ->
+val to_string_exn : ?len:int -> ?encoding:encoding ->
+  ?string_style:scalar_style ->
+  ?scalar_style:scalar_style ->
   ?layout_style:layout_style -> value -> string
 (** [to_string_exn v] acts as {!to_string}, but raises {!Invalid_argument} in
   if there is an error. *)


### PR DESCRIPTION
This allows to use i.e. plain style but still having strings enclosed
in quotes.