### PR TITLE
Add test dependency on crowbar.

### DIFF
--- a/yaml.opam
+++ b/yaml.opam
@@ -19,6 +19,7 @@ depends: [
   "bos"
   "mdx" {with-test}
   "alcotest" {with-test}
+  "crowbar" {with-test}
   "junit_alcotest" {with-test}
   "ezjsonm" {with-test}
 ]


### PR DESCRIPTION
This should fix the `ocaml-ci` failure for `crowbar`.
It doesn't address the SEGV errors on 32bit ARM or x86.