### PR TITLE
Fix Yaml.to_string x |> Yaml.of_string resulting in different values

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@
   an alias that also includes the Sexp conversion functions in
   its scope. (@alan-j-hu @avsm #46).
 
+* When outputting values, wrap special values like "true" or
+  "1.0" in double quotes, so that `Yaml.of_string` will not
+  interpret them as a non-string value.
+
 * Track anchors and mappings in `Yaml.yaml` (but not in the
   `Yaml.value` JSON representation). This also allows non-scalar
    values to be used as keys. (@favonia #38)

--- a/lib/yaml.ml
+++ b/lib/yaml.ml
@@ -75,7 +75,13 @@ let to_string ?len ?(encoding=`Utf8) ?scalar_style ?layout_style (v:value) =
   document_start t >>= fun () ->
   let rec iter = function
      |`Null -> Stream.scalar (scalar "") t
-     |`String s -> Stream.scalar (scalar ?style:scalar_style s) t
+     |`String s ->
+        let style =
+          match yaml_scalar_to_json s with
+          | `String s -> scalar_style
+          | _ -> Some `Double_quoted
+        in
+        Stream.scalar (scalar ?style ~quoted_implicit:true s) t
      |`Float s -> Stream.scalar (scalar (Printf.sprintf "%.16g" s)) t
      (* NOTE: Printf format on the line above taken from the jsonm library *)
      |`Bool s -> Stream.scalar (scalar (string_of_bool s)) t


### PR DESCRIPTION
When outputting values, wrap special values like "true" or
"1.0" in double quotes, so that `Yaml.of_string` will not
interpret them as a non-string value.

For example, Yaml.to_string (`String "1.0") will be double quoted
but Yaml.to_string (`String "foo") will not.

Fixes #39 