### PR TITLE
Make `yaml` work in monorepos

### DIFF
--- a/config/discover.ml
+++ b/config/discover.ml
@@ -13,11 +13,13 @@ let ppc64_lines c =
   | "power", "ppc64le" -> ["-mcmodel=small"]
   | _ -> []
 
+external realpath : string -> string = "caml_unix_realpath"
+
 let () =
   let cstubs = ref "" in
   let args = Arg.["-cstubs",Set_string cstubs,"cstubs loc"] in
   C.main ~args ~name:"yaml" (fun c ->
-    let cstubs_cflags = Printf.sprintf "-I%s" (Filename.dirname !cstubs) in
+    let cstubs_cflags = Printf.sprintf "-I%s" (realpath (Filename.dirname !cstubs)) in
     let lines = ocamlopt_lines c @ ppc64_lines c in
     C.Flags.write_lines "cflags" lines;
     C.Flags.write_lines "ctypes-cflags" [cstubs_cflags]

--- a/config/dune
+++ b/config/dune
@@ -1,8 +1,15 @@
 (executable
  (name discover)
- (libraries dune.configurator))
+ (libraries dune.configurator)
+ (foreign_stubs
+  (language c)
+  (names realpath)))
 
 (rule
  (targets cflags ctypes-cflags)
- (action (run ./discover.exe -cstubs %{lib:ctypes:ctypes_cstubs_internals.h})))
-
+ (deps %{lib:ctypes:ctypes_primitives.h} %{lib:ctypes:ocaml_integers.h}
+   %{lib:ctypes:ctypes_complex_stubs.h} %{lib:ctypes:ctypes_ldouble_stubs.h}
+   %{lib:ctypes:ctypes_raw_pointer.h}
+   %{lib:ctypes:ctypes_managed_buffer_stubs.h})
+ (action
+  (run ./discover.exe -cstubs %{lib:ctypes:ctypes_cstubs_internals.h})))

--- a/config/realpath.c
+++ b/config/realpath.c
@@ -1,0 +1,19 @@
+#include <caml/mlvalues.h>
+#include <caml/memory.h>
+#include <caml/alloc.h>
+#include <caml/fail.h>
+#include <caml/callback.h>
+#include <errno.h>
+
+CAMLprim value caml_unix_realpath (value p)
+{
+  CAMLparam1 (p);
+  char *r;
+  value rp;
+
+  r = realpath (String_val (p), NULL);
+  if (r == NULL) { caml_invalid_argument ("realpath returned NULL");  }
+  rp = caml_copy_string (r);
+  free (r);
+  CAMLreturn (rp);
+}

--- a/dune
+++ b/dune
@@ -1,6 +1,13 @@
-(env (_ (flags (:standard -w -9-27-32))))
-(alias
- (name readme)
- (deps README.md)
- (action (progn (run mdx test %{deps}) (diff? %{deps} %{deps}.corrected))))
+(env
+ (_
+  (flags
+   (:standard -w -9-27-32))))
 
+(rule
+ (alias readme)
+ (deps
+  (:readme README.md))
+ (action
+  (progn
+   (run ocaml-mdx test %{readme})
+   (diff? %{readme} %{readme}.corrected))))

--- a/dune-project
+++ b/dune-project
@@ -1,2 +1,2 @@
-(lang dune 1.3)
+(lang dune 2.0)
 (name yaml)

--- a/ffi/lib/dune
+++ b/ffi/lib/dune
@@ -1,20 +1,32 @@
-
 (rule
  (targets g.ml)
  (deps ../stubgen/ffi_stubgen.exe)
- (action (with-stdout-to %{targets} (run %{deps} -ml))))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run %{deps} -ml))))
 
 (rule
  (targets yaml_stubs.c)
- (deps (:stubgen ../stubgen/ffi_stubgen.exe) ../../vendor/yaml.h ../../vendor/yaml_private.h)
- (action (with-stdout-to %{targets} (run %{stubgen} -c))))
+ (deps
+  (:stubgen ../stubgen/ffi_stubgen.exe)
+  ../../vendor/yaml.h
+  ../../vendor/yaml_private.h)
+ (action
+  (with-stdout-to
+   %{targets}
+   (run %{stubgen} -c))))
 
 (library
  (name yaml_ffi)
  (public_name yaml.ffi)
  (modules g m)
- (c_names yaml_stubs)
- (flags (:standard -w -9-27-32-34))
- (c_flags ((:standard \ -fPIC) -I../../vendor))
+ (foreign_stubs
+  (language c)
+  (names yaml_stubs)
+  (flags
+   ((:standard \ -fPIC)
+    -I../../vendor)))
+ (flags
+  (:standard -w -9-27-32-34))
  (libraries yaml.bindings yaml.types ctypes.stubs ctypes yaml.c))
-

--- a/lib_sexp/dune
+++ b/lib_sexp/dune
@@ -2,4 +2,5 @@
  (name yaml_sexp)
  (public_name yaml-sexp)
  (libraries yaml sexplib)
- (preprocess (pps ppx_sexp_conv)))
+ (preprocess
+  (pps ppx_sexp_conv)))

--- a/tests/dune
+++ b/tests/dune
@@ -2,13 +2,17 @@
  (name test)
  (package yaml)
  (libraries yaml bos ezjsonm alcotest junit_alcotest)
- (modules test test_parse test_reflect test_event_parse test_emit test_version test_util)
- (deps (source_tree yaml)))
+ (modules test test_parse test_reflect test_event_parse test_emit
+   test_version test_util)
+ (deps
+  (source_tree yaml)))
 
 (test
  (name test_sexp)
  (package yaml-sexp)
  (libraries yaml-sexp bos alcotest junit_alcotest)
  (modules test_sexp test_parse_sexp)
- (preprocess (pps ppx_sexp_conv))
- (deps (source_tree yaml)))
+ (preprocess
+  (pps ppx_sexp_conv))
+ (deps
+  (source_tree yaml)))

--- a/types/lib/dune
+++ b/types/lib/dune
@@ -1,7 +1,10 @@
 (rule
  (targets g.ml)
  (deps ../stubgen/ffi_ml_types_stubgen.exe)
- (action (with-stdout-to %{targets} (run %{deps}))))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run %{deps}))))
 
 (library
  (name yaml_types)

--- a/types/stubgen/dune
+++ b/types/stubgen/dune
@@ -6,10 +6,16 @@
 (rule
  (targets ffi_ml_types_stubgen.c)
  (deps ./ffi_types_stubgen.exe)
- (action (with-stdout-to %{targets} (run %{deps}))))
+ (action
+  (with-stdout-to
+   %{targets}
+   (run %{deps}))))
 
 (rule
  (targets ffi_ml_types_stubgen.exe)
- (deps    (:c ./ffi_ml_types_stubgen.c) ../../vendor/libyaml_c_stubs.a)
- (action (run %{cc} %{c} -I../../vendor %{read-lines:../../config/ctypes-cflags} 
-  -I %{ocaml_where} -o %{targets})))
+ (deps
+  (:c ./ffi_ml_types_stubgen.c)
+  ../../vendor/libyaml_c_stubs.a)
+ (action
+  (run %{cc} %{c} -I../../vendor %{read-lines:../../config/ctypes-cflags} -I
+    %{ocaml_where} -o %{targets})))

--- a/vendor/dune
+++ b/vendor/dune
@@ -1,47 +1,83 @@
 (library
- (name        yaml_c)
+ (name yaml_c)
  (public_name yaml.c)
  (preprocess no_preprocessing)
- (flags (:standard -safe-string))
- (self_build_stubs_archive (yaml_c)))
+ (flags
+  (:standard -safe-string))
+ (foreign_archives yaml_c_stubs))
 
 (rule
  (targets libyaml_c_stubs%{ext_lib} dllyaml_c_stubs%{ext_dll})
- (deps   api.o emitter.o loader.o parser.o reader.o scanner.o writer.o)
- (action (run ocamlmklib -o yaml_c_stubs %{deps})))
+ (deps api.o emitter.o loader.o parser.o reader.o scanner.o writer.o)
+ (action
+  (run ocamlmklib -o yaml_c_stubs %{deps})))
 
 (rule
  (targets api.o)
- (deps    (:c api.c) yaml.h config.h yaml_private.h)
- (action  (run %{cc} %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
+ (deps
+  (:c api.c)
+  yaml.h
+  config.h
+  yaml_private.h)
+ (action
+  (run %{cc} %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
 
 (rule
  (targets emitter.o)
- (deps    (:c emitter.c) yaml.h config.h yaml_private.h)
- (action  (run %{cc}  %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
+ (deps
+  (:c emitter.c)
+  yaml.h
+  config.h
+  yaml_private.h)
+ (action
+  (run %{cc} %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
 
 (rule
  (targets loader.o)
- (deps    (:c loader.c) yaml.h config.h yaml_private.h)
- (action  (run %{cc}  %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
+ (deps
+  (:c loader.c)
+  yaml.h
+  config.h
+  yaml_private.h)
+ (action
+  (run %{cc} %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
 
 (rule
  (targets parser.o)
- (deps    (:c parser.c) yaml.h config.h yaml_private.h)
- (action  (run %{cc} %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
+ (deps
+  (:c parser.c)
+  yaml.h
+  config.h
+  yaml_private.h)
+ (action
+  (run %{cc} %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
 
 (rule
  (targets reader.o)
- (deps    (:c reader.c) yaml.h config.h yaml_private.h)
- (action  (run %{cc} %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
+ (deps
+  (:c reader.c)
+  yaml.h
+  config.h
+  yaml_private.h)
+ (action
+  (run %{cc} %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
 
 (rule
  (targets scanner.o)
- (deps    (:c scanner.c) yaml.h config.h yaml_private.h)
- (action  (run %{cc} %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
+ (deps
+  (:c scanner.c)
+  yaml.h
+  config.h
+  yaml_private.h)
+ (action
+  (run %{cc} %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
 
 (rule
  (targets writer.o)
- (deps    (:c writer.c) yaml.h config.h yaml_private.h)
- (action  (run %{cc} %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
-
+ (deps
+  (:c writer.c)
+  yaml.h
+  config.h
+  yaml_private.h)
+ (action
+  (run %{cc} %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))

--- a/yaml-sexp.opam
+++ b/yaml-sexp.opam
@@ -15,11 +15,11 @@ homepage: "https://github.com/avsm/ocaml-yaml"
 doc: "https://avsm.github.io/ocaml-yaml/"
 bug-reports: "https://github.com/avsm/ocaml-yaml/issues"
 depends: [
-  "dune" {>= "1.3"}
+  "dune" {>= "2.0"}
   "ppx_sexp_conv" {>= "v0.9.0"}
   "sexplib"
   "yaml" {= version}
-  "mdx" {with-test}
+  "mdx" {with-test & >= "2.1.0"}
   "alcotest" {with-test}
   "crowbar" {with-test}
   "junit_alcotest" {with-test}

--- a/yaml.opam
+++ b/yaml.opam
@@ -23,13 +23,13 @@ doc: "https://avsm.github.io/ocaml-yaml/"
 bug-reports: "https://github.com/avsm/ocaml-yaml/issues"
 depends: [
   "ocaml" {>= "4.08.0"}
-  "dune" {>= "1.3"}
+  "dune" {>= "2.0"}
   "dune-configurator"
   "ctypes" {>= "0.12.0"}
   "bos"
   "fmt" {with-test}
   "logs" {with-test}
-  "mdx" {with-test}
+  "mdx" {with-test & >= "2.1.0"}
   "alcotest" {with-test}
   "crowbar" {with-test}
   "junit_alcotest" {with-test}


### PR DESCRIPTION
This PR is in two parts:

- first an upgrade to dune 2.0
- then two changes to make `yaml` work in monorepos:
   - use `realpath` to make ctypes' include path absolute, because `%{lib:ctypes:ctypes_cstubs_internals.h}` is relative in a monorepo. I have added a _C stub_ for it, because `Unix.realpath` only exists since 4.13.
   - add explicit dependencies for all the header files that are used. Otherwise they don't get installed. 