### PR TITLE
Support MSVC compiler

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Pending
+
+* Support MSVC with .obj and .lib extensions, and defining
+  -DDYAML_DECLARE_EXPORT (@jonahbeckford #53)
+
 ## v3.0.1 (04/02/2022)
 
 * Remove dependency on Rresult (@maxtori #50).

--- a/config/discover.ml
+++ b/config/discover.ml
@@ -13,12 +13,18 @@ let ppc64_lines c =
   | "power", "ppc64le" -> ["-mcmodel=small"]
   | _ -> []
 
+let dll_lines c =
+  let ccomp_type = C.ocaml_config_var_exn c "ccomp_type" in
+  match ccomp_type with
+  | "msvc" -> ["-DYAML_DECLARE_EXPORT"]
+  | _ -> []
+
 let () =
   let cstubs = ref "" in
   let args = Arg.["-cstubs",Set_string cstubs,"cstubs loc"] in
   C.main ~args ~name:"yaml" (fun c ->
     let cstubs_cflags = Printf.sprintf "-I%s" (Filename.dirname !cstubs) in
-    let lines = ocamlopt_lines c @ ppc64_lines c in
+    let lines = ocamlopt_lines c @ ppc64_lines c @ dll_lines c in
     C.Flags.write_lines "cflags" lines;
     C.Flags.write_lines "ctypes-cflags" [cstubs_cflags]
   )

--- a/types/stubgen/dune
+++ b/types/stubgen/dune
@@ -10,6 +10,6 @@
 
 (rule
  (targets ffi_ml_types_stubgen.exe)
- (deps    (:c ./ffi_ml_types_stubgen.c) ../../vendor/libyaml_c_stubs.a)
+ (deps    (:c ./ffi_ml_types_stubgen.c) ../../vendor/libyaml_c_stubs%{ext_lib})
  (action (run %{cc} %{c} -I../../vendor %{read-lines:../../config/ctypes-cflags} 
   -I %{ocaml_where} -o %{targets})))

--- a/vendor/dune
+++ b/vendor/dune
@@ -7,41 +7,41 @@
 
 (rule
  (targets libyaml_c_stubs%{ext_lib} dllyaml_c_stubs%{ext_dll})
- (deps   api.o emitter.o loader.o parser.o reader.o scanner.o writer.o)
+ (deps   api%{ext_obj} emitter%{ext_obj} loader%{ext_obj} parser%{ext_obj} reader%{ext_obj} scanner%{ext_obj} writer%{ext_obj})
  (action (run ocamlmklib -o yaml_c_stubs %{deps})))
 
 (rule
- (targets api.o)
+ (targets api%{ext_obj})
  (deps    (:c api.c) yaml.h config.h yaml_private.h)
  (action  (run %{cc} %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
 
 (rule
- (targets emitter.o)
+ (targets emitter%{ext_obj})
  (deps    (:c emitter.c) yaml.h config.h yaml_private.h)
  (action  (run %{cc}  %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
 
 (rule
- (targets loader.o)
+ (targets loader%{ext_obj})
  (deps    (:c loader.c) yaml.h config.h yaml_private.h)
  (action  (run %{cc}  %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
 
 (rule
- (targets parser.o)
+ (targets parser%{ext_obj})
  (deps    (:c parser.c) yaml.h config.h yaml_private.h)
  (action  (run %{cc} %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
 
 (rule
- (targets reader.o)
+ (targets reader%{ext_obj})
  (deps    (:c reader.c) yaml.h config.h yaml_private.h)
  (action  (run %{cc} %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
 
 (rule
- (targets scanner.o)
+ (targets scanner%{ext_obj})
  (deps    (:c scanner.c) yaml.h config.h yaml_private.h)
  (action  (run %{cc} %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
 
 (rule
- (targets writer.o)
+ (targets writer%{ext_obj})
  (deps    (:c writer.c) yaml.h config.h yaml_private.h)
  (action  (run %{cc} %{read-lines:../config/cflags} -Wall -DHAVE_CONFIG_H -I. -c %{c})))
 


### PR DESCRIPTION
1. Define `YAML_DECLARE_EXPORT` so vendored yaml C code does not use the default "import" which is for when there is already a yaml DLL; without it MSVC complains that the functions are being defined even though DLL import is on. That is:

```
# writer.c(33): error C2491: 'yaml_emitter_flush': definition of dllimport function not allowed
# writer.c(107): warning C4244: '=': conversion from 'unsigned int' to 'unsigned char', possible loss of data
# writer.c(117): warning C4244: '=': conversion from 'unsigned int' to 'unsigned char', possible loss of data
```

2. Use .lib and .obj on Windows, which fixes:

```
# File "types/stubgen/dune", line 11, characters 0-232:
# 11 | (rule
# 12 |  (targets ffi_ml_types_stubgen.exe)
# 13 |  (deps    (:c ./ffi_ml_types_stubgen.c) ../../vendor/libyaml_c_stubs.a)
# 14 |  (action (run %{cc} %{c} -I../../vendor %{read-lines:../../config/ctypes-cflags}
# 15 |   -I %{ocaml_where} -o %{targets})))
# Error: No rule found for vendor/libyaml_c_stubs.a
```