### PR TITLE
Optimize `Yaml_unix.to_file` using `yaml_emitter_set_output_file`

### DIFF
--- a/ffi/bindings/yaml_bindings.ml
+++ b/ffi/bindings/yaml_bindings.ml
@@ -62,6 +62,13 @@ module M (F : Ctypes.FOREIGN) = struct
         @-> ptr size_t
         @-> returning void)
 
+  let emitter_set_output_file =
+    foreign "yaml_emitter_set_output_file"
+      C.(
+        ptr T.Emitter.t
+        @-> ptr void
+        @-> returning void)
+
   (* TODO static funptr
      let write_handler = C.(ptr void @-> ptr uchar @-> size_t @-> returning int)
 

--- a/lib/stream.ml
+++ b/lib/stream.ml
@@ -280,6 +280,17 @@ let emitter ?(len = 65535 * 4) () =
   | 1 -> Ok { e; event; written; buf }
   | n -> Error (`Msg ("error initialising emitter: " ^ string_of_int n))
 
+let emitter_file file =
+  let e = Ctypes.(allocate_n T.Emitter.t ~count:1) in
+  let event = Ctypes.(allocate_n T.Event.t ~count:1) in
+  let written = Ctypes.allocate_n Ctypes.size_t ~count:1 in (* TODO: unused *)
+  let r = B.emitter_init e in
+  let buf = Bytes.create 0 in (* TODO: unused *)
+  B.emitter_set_output_file e file;
+  match r with
+  | 1 -> Ok { e; event; written; buf }
+  | n -> Error (`Msg ("error initialising emitter: " ^ string_of_int n))
+
 let emitter_buf { buf; written } =
   Ctypes.(!@written) |> Unsigned.Size_t.to_int |> Bytes.sub buf 0
 

--- a/lib/yaml.ml
+++ b/lib/yaml.ml
@@ -78,8 +78,7 @@ let of_json (v : value) =
   in
   match fn v with r -> Ok r | exception Failure msg -> Error (`Msg msg)
 
-let to_string ?len ?(encoding = `Utf8) ?scalar_style ?layout_style (v : value) =
-  emitter ?len () >>= fun t ->
+let to_emitter ?(encoding = `Utf8) ?scalar_style ?layout_style (t: emitter) (v : value) =
   stream_start t encoding >>= fun () ->
   document_start t >>= fun () ->
   let rec iter = function
@@ -113,7 +112,11 @@ let to_string ?len ?(encoding = `Utf8) ?scalar_style ?layout_style (v : value) =
   in
   iter v >>= fun () ->
   document_end t >>= fun () ->
-  stream_end t >>= fun () ->
+  stream_end t
+
+let to_string ?len ?(encoding = `Utf8) ?scalar_style ?layout_style (v : value) =
+  emitter ?len () >>= fun t ->
+  to_emitter ~encoding ?scalar_style ?layout_style t v >>= fun () ->
   let r = Stream.emitter_buf t in
   Ok (Bytes.to_string r)
 

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -277,6 +277,8 @@ module Stream : sig
       buffer that the output is written into is. In the future, [len] will be
       redundant as the buffer will be dynamically allocated. *)
 
+  val emitter_file : unit Ctypes.ptr -> emitter res
+
   val emitter_buf : emitter -> Bytes.t
   val emit : emitter -> Event.t -> unit res
   val document_start : ?version:version -> ?implicit:bool -> emitter -> unit res
@@ -311,6 +313,14 @@ module Stream : sig
   (** [library_version ()] returns the major, minor and patch version of the
       underlying libYAML implementation. *)
 end
+
+val to_emitter :
+  ?encoding:encoding ->
+  ?scalar_style:scalar_style ->
+  ?layout_style:layout_style ->
+  Stream.emitter ->
+  value ->
+  unit res
 
 (** {2 Utility functions for yaml}
 

--- a/types/bindings/dune
+++ b/types/bindings/dune
@@ -1,4 +1,4 @@
 (library
  (name yaml_bindings_types)
  (public_name yaml.bindings.types)
- (libraries ctypes.stubs ctypes))
+ (libraries ctypes.stubs ctypes ctypes.foreign))

--- a/unix/yaml_unix.mli
+++ b/unix/yaml_unix.mli
@@ -22,6 +22,10 @@ val of_file_exn : Fpath.t -> Yaml.value
 (** [of_file_exn p] acts as {!of_file}, but errors are thrown as a {!Failure}
     exception instead of in the return value. *)
 
+val to_channel : ?encoding:Yaml.encoding ->
+    ?scalar_style:Yaml.scalar_style ->
+    ?layout_style:Yaml.layout_style -> out_channel -> Yaml.value -> (unit, [ `Msg of string ]) result
+
 val to_file : Fpath.t -> Yaml.value -> (unit, [ `Msg of string ]) result
 (** [to_file p v] will convert the Yaml value [v] to a string and write it to
     the file at path [p]. *)


### PR DESCRIPTION
When trying to write some larger YAML files, I was surprised by very confusing `scalar failed` errors.
Turns out `Yaml_unix.to_file` is very naïve and converts the entire thing to a string in memory before writing it entirely:
https://github.com/avsm/ocaml-yaml/blob/d4fe98a69db746f85191fea2ccba1d7a9bcdba82/unix/yaml_unix.ml#L18
And of course that `to_string` is limited by the fixed-size buffer:
https://github.com/avsm/ocaml-yaml/blob/d4fe98a69db746f85191fea2ccba1d7a9bcdba82/lib/yaml.mli#L144-L147

The workaround would be to use a bigger `len`, but it might be difficult to estimate the serialized length of the YAML object to set the buffer length accordingly (while not massively overallocating).

Therefore this is an attempt to use `yaml_emitter_set_output_file` from libyaml to implement `to_file` using an emitter, which directly writes to a file, avoiding the intermediate C buffer and OCaml string. As is, it seems to work but needs to be polished, since ctypes is new to me.

### TODO
- [ ] `yaml_emitter_set_output_file` takes `FILE*` argument for which I currently use `ptr void`, is there anything better?
- [ ] `Stream.emitter` type is currently specifically for the buffer-based output, but the `buf` and `written` fields aren't needed for `emitter_file`. Probably makes sense to use a variant inside `emitter`, but should it be changed to a GADT, which distinguishes emitters created for different outputs to forbid calling `emitter_buf` on a file output emitter? A GADT would be a breaking interface change, so maybe just a runtime exception for misuse is good enough?
- [ ] `Obj.magic` is used to cast `Unix.file_descr` to `int`. Could add an extra dependency for [unix-type-representations](https://opam.ocaml.org/packages/unix-type-representations/) to do the same (which just uses `Obj.magic` as well), but is it worth it?
- [ ] ctypes-foreign is used to call `fdopen` to take the file descriptor `int` and get a `FILE*` (really `ptr void`) to give to libyaml. Should probably use ctypes stubs for it instead.
- [ ] To be symmetric, a similar optimization could be done to `of_file`, I suppose. 