### PR TITLE
Remove remaining references to Rresult

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ locally by running `dune utop`.
 - : string Yaml.res = Result.Ok "foo1: bar1\nfoo2: 1\n"
 # #require "yaml.unix" ;;
 # Yaml_unix.to_file Fpath.(v "my.yml") (`String "bar") ;;
-- : (unit, Rresult.R.msg) result = Result.Ok ()
+- : (unit, [ `Msg of string ]) result = Result.Ok ()
 # Yaml_unix.of_file Fpath.(v "my.yml");;
-- : (Yaml.value, Rresult.R.msg) result = Result.Ok (`String "bar")
+- : (Yaml.value, [ `Msg of string ]) result = Result.Ok (`String "bar")
 # Yaml_unix.of_file_exn Fpath.(v "my.yml");;
 - : Yaml.value = `String "bar"
 ```
@@ -106,7 +106,6 @@ We use the following major OCaml tools and libraries:
 - **build:** [dune](https://github.com/janestreet/dune) is the build tool used.
 - **ffi:** [ctypes](https://github.com/ocamllabs/ocaml-ctypes) is the library to interface with the C FFI exposed by libYaml.
 - **preprocessor:** [ppx_sexp_conv](https://github.com/janestreet/ppx_sexp_conv) generates s-expression serialises and deserialisers for the types exposed by the library, exposed in a `yaml-sexp` package.
-- **error handling:** [rresult](https://github.com/dbuenzli/rresult) is a set of combinators for returning errors as values, instead of raising OCaml exceptions.
 - **tests:** [alcotest](https://github.com/mirage/alcotest) specifies conventional unit tests, and [crowbar](https://github.com/stedolan/crowbar) is used to drive property-based fuzz-testing of the library.
 
 #### Library Architecture
@@ -155,8 +154,8 @@ to compile with the C header files for the yaml library.  The resulting OCaml fu
 are exported in the `yaml.ffi` ocamlfind library.
 
 **OCaml API:** Finally, we define the OCaml API that uses the low-level FFI to expose
-a well-typed OCaml interface. We adopt a convention of using the [Rresult](https://github.com/dbuenzli/rresult)
-library to return explicit errors instead of raising OCaml exceptions.  We also
+a well-typed OCaml interface. We adopt a convention of using the standard `result`
+type to return explicit errors instead of raising OCaml exceptions.  We also
 define some polymorphic variant types to represent various configuration options
 (such as the printing style of different Yaml values).
 

--- a/fuzz/fuzz.ml
+++ b/fuzz/fuzz.ml
@@ -13,8 +13,8 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. *)
 
 open Crowbar
-open Rresult
-open R.Infix
+
+let ( >>= ) = Result.bind
 
 (* Consume all the events in a stream using the
    low-level API and return a bool to indicate success *)

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -116,8 +116,8 @@ type layout_style = [ `Any | `Block | `Flow ]
       notation. *)
 
 type 'a res = ('a, [ `Msg of string ]) result
-(** This library uses the {!Rresult.R.msg} conventions for returning errors
-    rather than raising exceptions. *)
+(** This library uses the standard {!result} type for returning errors rather
+    than raising exceptions. *)
 
 (** {2 Serialisers and deserialisers}
 

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -58,7 +58,7 @@ let quoted_scalars =
   (* Given an input string, we want to test two things:
      - if the input is parsed as an expected Yaml.value and;
      - if encoding the parsed Yaml.yaml results in the original string. *)
-  let open Rresult.R.Infix in
+  let ( >>= ) = Result.bind in
   let test name str expected =
     let actual_yaml = Yaml.yaml_of_string str in
     let actual_value = actual_yaml >>= Yaml.to_json in

--- a/tests/test_emit.ml
+++ b/tests/test_emit.ml
@@ -12,9 +12,9 @@
  * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. *)
 
-open Rresult
-open R.Infix
 module S = Yaml.Stream
+
+let ( >>= ) = Result.bind
 
 let scalar ?anchor ?tag ?(plain_implicit = true) ?(quoted_implicit = false)
     ?(style = `Plain) value : Yaml.scalar =

--- a/tests/test_event_parse.ml
+++ b/tests/test_event_parse.ml
@@ -13,16 +13,14 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. *)
 
 module T = Yaml_types.M
-open Rresult
+
+let ( >>= ) = Result.bind
 
 let v file =
-  let open R.Infix in
   Bos.OS.File.read file >>= fun buf ->
   Yaml.Stream.parser buf >>= fun t ->
   let rec iter_until_done fn =
     Yaml.Stream.do_parse t >>= fun (e, _pos) ->
-    match e with
-    | Yaml.Stream.Event.Nothing -> R.ok ()
-    | _ -> iter_until_done fn
+    match e with Yaml.Stream.Event.Nothing -> Ok () | _ -> iter_until_done fn
   in
   iter_until_done ()

--- a/tests/test_parse.ml
+++ b/tests/test_parse.ml
@@ -1,7 +1,6 @@
-open Rresult
+let ( >>= ) = Result.bind
 
 let v file =
-  let open R.Infix in
   Bos.OS.File.read file >>= fun buf ->
   Yaml.yaml_of_string buf >>= fun v ->
   Yaml.to_json v >>= fun json ->

--- a/tests/test_parse_sexp.ml
+++ b/tests/test_parse_sexp.ml
@@ -1,9 +1,8 @@
-open Rresult
+let ( >>= ) = Result.bind
 
 type t = { v : Yaml_sexp.value } [@@deriving sexp]
 
 let v file =
-  let open R.Infix in
   Bos.OS.File.read file >>= fun buf ->
   Yaml.yaml_of_string buf >>= fun v ->
   Yaml_sexp.sexp_of_yaml v |> fun s ->

--- a/tests/test_reflect.ml
+++ b/tests/test_reflect.ml
@@ -13,19 +13,18 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE. *)
 
 module T = Yaml_types.M
-open Rresult
 
+let ( >>= ) = Result.bind
 let reflect e ev pos = Yaml.Stream.emit e ev
 
 let v file =
-  let open R.Infix in
   Bos.OS.File.read file >>= fun buf ->
   Yaml.Stream.parser buf >>= fun t ->
   Yaml.Stream.emitter () >>= fun e ->
   let rec iter_until_done fn =
     Yaml.Stream.do_parse t >>= fun (e, pos) ->
     match e with
-    | Yaml.Stream.Event.Nothing -> R.ok ()
+    | Yaml.Stream.Event.Nothing -> Ok ()
     | event -> fn event pos >>= fun () -> iter_until_done fn
   in
   iter_until_done (reflect e) >>= fun () ->


### PR DESCRIPTION
The rresult dependency was removed in #50, but some references remained around in the documentation and tests.

Technically it's not necessary to avoid `Rresult` in tests because the `Bos` dependency transitively depends on it, but it might be better to be consistent across the board.