### PR TITLE
Generalize and optimize outputs

### DIFF
--- a/ffi/bindings/yaml_bindings.ml
+++ b/ffi/bindings/yaml_bindings.ml
@@ -69,11 +69,16 @@ module M (F : Ctypes.FOREIGN) = struct
         @-> ptr void
         @-> returning void)
 
-  (* TODO static funptr *)
-  let write_handler = Ctypes.(ptr void @-> ptr uchar @-> size_t @-> returning int)
+  (* TODO: should this be in Yaml_bindings_types? *)
+  let write_handler_t = Ctypes.(ptr void @-> ptr uchar @-> size_t @-> returning int)
 
   let emitter_set_output =
-    foreign "yaml_emitter_set_output" C.(ptr T.Emitter.t @-> static_funptr write_handler @-> ptr void @-> returning void)
+    foreign "yaml_emitter_set_output"
+      C.(
+        ptr T.Emitter.t
+        @-> static_funptr write_handler_t
+        @-> ptr void
+        @-> returning void)
 
   let emitter_set_encoding =
     foreign "yaml_emitter_set_encoding"

--- a/ffi/bindings/yaml_bindings.ml
+++ b/ffi/bindings/yaml_bindings.ml
@@ -69,12 +69,11 @@ module M (F : Ctypes.FOREIGN) = struct
         @-> ptr void
         @-> returning void)
 
-  (* TODO static funptr
-     let write_handler = C.(ptr void @-> ptr uchar @-> size_t @-> returning int)
+  (* TODO static funptr *)
+  let write_handler = Ctypes.(ptr void @-> ptr uchar @-> size_t @-> returning int)
 
-     let emitter_set_output =
-       foreign "yaml_emitter_set_output" C.(ptr T.Emitter.t @-> (static_funptr write_handler) @-> ptr void @-> returning void)
-  *)
+  let emitter_set_output =
+    foreign "yaml_emitter_set_output" C.(ptr T.Emitter.t @-> static_funptr write_handler @-> ptr void @-> returning void)
 
   let emitter_set_encoding =
     foreign "yaml_emitter_set_encoding"

--- a/ffi/bindings/yaml_bindings.ml
+++ b/ffi/bindings/yaml_bindings.ml
@@ -64,13 +64,11 @@ module M (F : Ctypes.FOREIGN) = struct
 
   let emitter_set_output_file =
     foreign "yaml_emitter_set_output_file"
-      C.(
-        ptr T.Emitter.t
-        @-> ptr void
-        @-> returning void)
+      C.(ptr T.Emitter.t @-> ptr void @-> returning void)
 
   (* TODO: should this be in Yaml_bindings_types? *)
-  let write_handler_t = Ctypes.(ptr void @-> ptr uchar @-> size_t @-> returning int)
+  let write_handler_t =
+    Ctypes.(ptr void @-> ptr uchar @-> size_t @-> returning int)
 
   let emitter_set_output =
     foreign "yaml_emitter_set_output"

--- a/ffi/bindings/yaml_bindings.ml
+++ b/ffi/bindings/yaml_bindings.ml
@@ -62,6 +62,13 @@ module M (F : Ctypes.FOREIGN) = struct
         @-> ptr size_t
         @-> returning void)
 
+  let emitter_set_output_file =
+    foreign "yaml_emitter_set_output_file"
+      C.(
+        ptr T.Emitter.t
+        @-> ptr void
+        @-> returning void)
+
   (* TODO static funptr
      let write_handler = C.(ptr void @-> ptr uchar @-> size_t @-> returning int)
 

--- a/lib/dune
+++ b/lib/dune
@@ -1,4 +1,4 @@
 (library
  (name yaml)
  (public_name yaml)
- (libraries yaml.ffi))
+ (libraries yaml.ffi ctypes.foreign))

--- a/lib/stream.ml
+++ b/lib/stream.ml
@@ -322,8 +322,12 @@ let emitter_handler handler =
   | 1 -> Ok { e; event; kind = Handler }
   | n -> Error (`Msg ("error initialising emitter: " ^ string_of_int n))
 
-let emitter_buffer () =
-  let buf = Buffer.create 1024 in
+let emitter_buffer ?buf () =
+  let buf =
+    match buf with
+    | None -> Buffer.create 1024
+    | Some buf -> buf
+  in
   Result.bind (emitter_handler (Buffer.add_string buf)) @@ fun t ->
   Ok { t with kind = Buffer buf }
 

--- a/lib/stream.ml
+++ b/lib/stream.ml
@@ -298,11 +298,17 @@ let emitter_handler handler =
   let r = B.emitter_init e in
   let buf = Bytes.create 0 in (* TODO: unused *)
   let open Ctypes in
+  let handler _ buf len =
+    let buf' = Ctypes.(coerce (ptr uchar) (ptr char) buf) in
+    let s = Ctypes.(string_from_ptr buf' ~length:(Unsigned.Size_t.to_int len)) in
+    handler s;
+    1
+  in
   let f =
     coerce
       (Foreign.funptr B.write_handler)
       (static_funptr B.write_handler)
-      (fun _ -> handler)
+      handler
   in
   B.emitter_set_output e f Ctypes.null;
   match r with

--- a/lib/stream.ml
+++ b/lib/stream.ml
@@ -313,8 +313,8 @@ let emitter_handler handler =
   in
   let f =
     coerce
-      (Foreign.funptr B.write_handler)
-      (static_funptr B.write_handler)
+      (Foreign.funptr B.write_handler_t)
+      (static_funptr B.write_handler_t)
       handler
   in
   B.emitter_set_output e f Ctypes.null;

--- a/lib/stream.ml
+++ b/lib/stream.ml
@@ -280,6 +280,17 @@ let emitter ?(len = 65535 * 4) () =
   | 1 -> Ok { e; event; written; buf }
   | n -> Error (`Msg ("error initialising emitter: " ^ string_of_int n))
 
+let emitter_file file =
+  let e = Ctypes.(allocate_n T.Emitter.t ~count:1) in
+  let event = Ctypes.(allocate_n T.Event.t ~count:1) in
+  let written = Ctypes.allocate_n Ctypes.size_t ~count:1 in (* TODO: unused *)
+  let r = B.emitter_init e in
+  let buf = Bytes.create 0 in (* TODO: unused *)
+  B.emitter_set_output_file e file;
+  match r with
+  | 1 -> Ok { e; event; written; buf }
+  | n -> Error (`Msg ("error initialising emitter: " ^ string_of_int n))
+
 let emitter_buf { buf; written } =
   Ctypes.(!@written) |> Unsigned.Size_t.to_int |> Bytes.sub buf 0
 

--- a/lib/yaml.ml
+++ b/lib/yaml.ml
@@ -78,7 +78,8 @@ let of_json (v : value) =
   in
   match fn v with r -> Ok r | exception Failure msg -> Error (`Msg msg)
 
-let to_emitter ?(encoding = `Utf8) ?scalar_style ?layout_style (t: emitter) (v : value) =
+let to_emitter ?(encoding = `Utf8) ?scalar_style ?layout_style (t : emitter)
+    (v : value) =
   stream_start t encoding >>= fun () ->
   document_start t >>= fun () ->
   let rec iter = function
@@ -111,14 +112,11 @@ let to_emitter ?(encoding = `Utf8) ?scalar_style ?layout_style (t: emitter) (v :
         fn l
   in
   iter v >>= fun () ->
-  document_end t >>= fun () ->
-  stream_end t
+  document_end t >>= fun () -> stream_end t
 
 let to_string ?len ?encoding ?scalar_style ?layout_style (v : value) =
   let emitter =
-    match len with
-    | Some len -> emitter ~len ()
-    | None -> emitter_buffer ()
+    match len with Some len -> emitter ~len () | None -> emitter_buffer ()
   in
   emitter >>= fun t ->
   to_emitter ?encoding ?scalar_style ?layout_style t v >>= fun () ->
@@ -141,7 +139,8 @@ let to_buffer ?encoding ?scalar_style ?layout_style buf (v : value) =
   emitter_buffer ~buf () >>= fun t ->
   to_emitter ?encoding ?scalar_style ?layout_style t v
 
-let yaml_to_emitter ?(encoding = `Utf8) ?scalar_style ?layout_style (t : emitter) (v : yaml) =
+let yaml_to_emitter ?(encoding = `Utf8) ?scalar_style ?layout_style
+    (t : emitter) (v : yaml) =
   stream_start t encoding >>= fun () ->
   document_start t >>= fun () ->
   let rec iter = function
@@ -166,14 +165,11 @@ let yaml_to_emitter ?(encoding = `Utf8) ?scalar_style ?layout_style (t : emitter
         fn m_members
   in
   iter v >>= fun () ->
-  document_end t >>= fun () ->
-  stream_end t
+  document_end t >>= fun () -> stream_end t
 
 let yaml_to_string ?len ?encoding ?scalar_style ?layout_style v =
   let emitter =
-    match len with
-    | Some len -> emitter ~len ()
-    | None -> emitter_buffer ()
+    match len with Some len -> emitter ~len () | None -> emitter_buffer ()
   in
   emitter >>= fun t ->
   yaml_to_emitter ?encoding ?scalar_style ?layout_style t v >>= fun () ->

--- a/lib/yaml.ml
+++ b/lib/yaml.ml
@@ -129,8 +129,16 @@ let to_string_exn ?len ?encoding ?scalar_style ?layout_style s =
   | Ok s -> s
   | Error (`Msg m) -> raise (Invalid_argument m)
 
+let to_file_fast ?(encoding = `Utf8) ?scalar_style ?layout_style file (v : value) =
+  emitter_file file >>= fun t ->
+  to_emitter ~encoding ?scalar_style ?layout_style t v
+
 let to_channel ?(encoding = `Utf8) ?scalar_style ?layout_style oc (v : value) =
   emitter_handler (output_string oc) >>= fun t ->
+  to_emitter ~encoding ?scalar_style ?layout_style t v
+
+let to_buffer ?(encoding = `Utf8) ?scalar_style ?layout_style buf (v : value) =
+  emitter_buffer ~buf () >>= fun t ->
   to_emitter ~encoding ?scalar_style ?layout_style t v
 
 let yaml_to_string ?(encoding = `Utf8) ?scalar_style ?layout_style v =

--- a/lib/yaml.ml
+++ b/lib/yaml.ml
@@ -114,14 +114,14 @@ let to_emitter ?(encoding = `Utf8) ?scalar_style ?layout_style (t: emitter) (v :
   document_end t >>= fun () ->
   stream_end t
 
-let to_string ?len ?(encoding = `Utf8) ?scalar_style ?layout_style (v : value) =
+let to_string ?len ?encoding ?scalar_style ?layout_style (v : value) =
   let emitter =
     match len with
     | Some len -> emitter ~len ()
     | None -> emitter_buffer ()
   in
   emitter >>= fun t ->
-  to_emitter ~encoding ?scalar_style ?layout_style t v >>= fun () ->
+  to_emitter ?encoding ?scalar_style ?layout_style t v >>= fun () ->
   Ok (emitter_string t)
 
 let to_string_exn ?len ?encoding ?scalar_style ?layout_style s =
@@ -129,17 +129,17 @@ let to_string_exn ?len ?encoding ?scalar_style ?layout_style s =
   | Ok s -> s
   | Error (`Msg m) -> raise (Invalid_argument m)
 
-let to_file_fast ?(encoding = `Utf8) ?scalar_style ?layout_style file (v : value) =
+let to_file_fast ?encoding ?scalar_style ?layout_style file (v : value) =
   emitter_file file >>= fun t ->
-  to_emitter ~encoding ?scalar_style ?layout_style t v
+  to_emitter ?encoding ?scalar_style ?layout_style t v
 
-let to_channel ?(encoding = `Utf8) ?scalar_style ?layout_style oc (v : value) =
+let to_channel ?encoding ?scalar_style ?layout_style oc (v : value) =
   emitter_handler (output_string oc) >>= fun t ->
-  to_emitter ~encoding ?scalar_style ?layout_style t v
+  to_emitter ?encoding ?scalar_style ?layout_style t v
 
-let to_buffer ?(encoding = `Utf8) ?scalar_style ?layout_style buf (v : value) =
+let to_buffer ?encoding ?scalar_style ?layout_style buf (v : value) =
   emitter_buffer ~buf () >>= fun t ->
-  to_emitter ~encoding ?scalar_style ?layout_style t v
+  to_emitter ?encoding ?scalar_style ?layout_style t v
 
 let yaml_to_emitter ?(encoding = `Utf8) ?scalar_style ?layout_style (t : emitter) (v : yaml) =
   stream_start t encoding >>= fun () ->
@@ -169,27 +169,27 @@ let yaml_to_emitter ?(encoding = `Utf8) ?scalar_style ?layout_style (t : emitter
   document_end t >>= fun () ->
   stream_end t
 
-let yaml_to_string ?len ?(encoding = `Utf8) ?scalar_style ?layout_style v =
+let yaml_to_string ?len ?encoding ?scalar_style ?layout_style v =
   let emitter =
     match len with
     | Some len -> emitter ~len ()
     | None -> emitter_buffer ()
   in
   emitter >>= fun t ->
-  yaml_to_emitter ~encoding ?scalar_style ?layout_style t v >>= fun () ->
+  yaml_to_emitter ?encoding ?scalar_style ?layout_style t v >>= fun () ->
   Ok (emitter_string t)
 
-let yaml_to_file_fast ?(encoding = `Utf8) ?scalar_style ?layout_style file v =
+let yaml_to_file_fast ?encoding ?scalar_style ?layout_style file v =
   emitter_file file >>= fun t ->
-  yaml_to_emitter ~encoding ?scalar_style ?layout_style t v
+  yaml_to_emitter ?encoding ?scalar_style ?layout_style t v
 
-let yaml_to_channel ?(encoding = `Utf8) ?scalar_style ?layout_style oc v =
+let yaml_to_channel ?encoding ?scalar_style ?layout_style oc v =
   emitter_handler (output_string oc) >>= fun t ->
-  yaml_to_emitter ~encoding ?scalar_style ?layout_style t v
+  yaml_to_emitter ?encoding ?scalar_style ?layout_style t v
 
-let yaml_to_buffer ?(encoding = `Utf8) ?scalar_style ?layout_style buf v =
+let yaml_to_buffer ?encoding ?scalar_style ?layout_style buf v =
   emitter_buffer ~buf () >>= fun t ->
-  yaml_to_emitter ~encoding ?scalar_style ?layout_style t v
+  yaml_to_emitter ?encoding ?scalar_style ?layout_style t v
 
 let yaml_of_string s =
   let open Event in

--- a/lib/yaml.ml
+++ b/lib/yaml.ml
@@ -115,10 +115,10 @@ let to_emitter ?(encoding = `Utf8) ?scalar_style ?layout_style (t: emitter) (v :
   stream_end t
 
 let to_string ?len ?(encoding = `Utf8) ?scalar_style ?layout_style (v : value) =
-  emitter ?len () >>= fun t ->
+  let buf = Buffer.create 1024 in
+  emitter_handler (Buffer.add_string buf) >>= fun t ->
   to_emitter ~encoding ?scalar_style ?layout_style t v >>= fun () ->
-  let r = Stream.emitter_buf t in
-  Ok (Bytes.to_string r)
+  Ok (Buffer.contents buf)
 
 let to_string_exn ?len ?encoding ?scalar_style ?layout_style s =
   match to_string ?len ?encoding ?scalar_style ?layout_style s with

--- a/lib/yaml.ml
+++ b/lib/yaml.ml
@@ -115,10 +115,14 @@ let to_emitter ?(encoding = `Utf8) ?scalar_style ?layout_style (t: emitter) (v :
   stream_end t
 
 let to_string ?len ?(encoding = `Utf8) ?scalar_style ?layout_style (v : value) =
-  let buf = Buffer.create 1024 in
-  emitter_handler (Buffer.add_string buf) >>= fun t ->
+  let emitter =
+    match len with
+    | Some len -> emitter ~len ()
+    | None -> emitter_buffer ()
+  in
+  emitter >>= fun t ->
   to_emitter ~encoding ?scalar_style ?layout_style t v >>= fun () ->
-  Ok (Buffer.contents buf)
+  Ok (emitter_string t)
 
 let to_string_exn ?len ?encoding ?scalar_style ?layout_style s =
   match to_string ?len ?encoding ?scalar_style ?layout_style s with

--- a/lib/yaml.ml
+++ b/lib/yaml.ml
@@ -78,8 +78,7 @@ let of_json (v : value) =
   in
   match fn v with r -> Ok r | exception Failure msg -> Error (`Msg msg)
 
-let to_string ?len ?(encoding = `Utf8) ?scalar_style ?layout_style (v : value) =
-  emitter ?len () >>= fun t ->
+let to_emitter ?(encoding = `Utf8) ?scalar_style ?layout_style (t: emitter) (v : value) =
   stream_start t encoding >>= fun () ->
   document_start t >>= fun () ->
   let rec iter = function
@@ -113,7 +112,11 @@ let to_string ?len ?(encoding = `Utf8) ?scalar_style ?layout_style (v : value) =
   in
   iter v >>= fun () ->
   document_end t >>= fun () ->
-  stream_end t >>= fun () ->
+  stream_end t
+
+let to_string ?len ?(encoding = `Utf8) ?scalar_style ?layout_style (v : value) =
+  emitter ?len () >>= fun t ->
+  to_emitter ~encoding ?scalar_style ?layout_style t v >>= fun () ->
   let r = Stream.emitter_buf t in
   Ok (Bytes.to_string r)
 

--- a/lib/yaml.ml
+++ b/lib/yaml.ml
@@ -129,6 +129,10 @@ let to_string_exn ?len ?encoding ?scalar_style ?layout_style s =
   | Ok s -> s
   | Error (`Msg m) -> raise (Invalid_argument m)
 
+let to_channel ?(encoding = `Utf8) ?scalar_style ?layout_style oc (v : value) =
+  emitter_handler (output_string oc) >>= fun t ->
+  to_emitter ~encoding ?scalar_style ?layout_style t v
+
 let yaml_to_string ?(encoding = `Utf8) ?scalar_style ?layout_style v =
   emitter () >>= fun t ->
   stream_start t encoding >>= fun () ->

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -277,6 +277,8 @@ module Stream : sig
       buffer that the output is written into is. In the future, [len] will be
       redundant as the buffer will be dynamically allocated. *)
 
+  val emitter_file : unit Ctypes.ptr -> emitter res
+
   val emitter_buf : emitter -> Bytes.t
   val emit : emitter -> Event.t -> unit res
   val document_start : ?version:version -> ?implicit:bool -> emitter -> unit res
@@ -311,6 +313,14 @@ module Stream : sig
   (** [library_version ()] returns the major, minor and patch version of the
       underlying libYAML implementation. *)
 end
+
+val to_emitter :
+  ?encoding:encoding ->
+  ?scalar_style:scalar_style ->
+  ?layout_style:layout_style ->
+  Stream.emitter ->
+  value ->
+  unit res
 
 (** {2 Utility functions for yaml}
 

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -156,6 +156,14 @@ val to_string_exn :
 (** [to_string_exn v] acts as {!to_string}, but raises {!Invalid_argument} in if
     there is an error. *)
 
+val to_channel :
+  ?encoding:encoding ->
+  ?scalar_style:scalar_style ->
+  ?layout_style:layout_style ->
+  out_channel ->
+  value ->
+  unit res
+
 val pp : Format.formatter -> value -> unit
 (** [pp ppf s] will output the Yaml value [s] to the formatter [ppf]. *)
 

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -143,8 +143,8 @@ val to_string :
   string res
 (** [to_string v] converts the JSON value to a Yaml string representation. The
     [encoding], [scalar_style] and [layout_style] control the various output
-    parameters. If [len] (in bytes) is specified, then a fixed-size buffer
-    is used internally. *)
+    parameters. If [len] (in bytes) is specified, then a fixed-size buffer is
+    used internally. *)
 
 val to_string_exn :
   ?len:int ->
@@ -164,9 +164,8 @@ val to_file_fast :
   value ->
   unit res
 (** [to_file_fast f v] converts the JSON value to a Yaml representation and
-    writes it to the file [f] given as [FILE*]. The
-    [encoding], [scalar_style] and [layout_style] control the various output
-    parameters. *)
+    writes it to the file [f] given as [FILE*]. The [encoding], [scalar_style]
+    and [layout_style] control the various output parameters. *)
 
 val to_channel :
   ?encoding:encoding ->
@@ -176,9 +175,8 @@ val to_channel :
   value ->
   unit res
 (** [to_channel oc v] converts the JSON value to a Yaml representation and
-    writes it to the channel [oc]. The
-    [encoding], [scalar_style] and [layout_style] control the various output
-    parameters. *)
+    writes it to the channel [oc]. The [encoding], [scalar_style] and
+    [layout_style] control the various output parameters. *)
 
 val to_buffer :
   ?encoding:encoding ->
@@ -187,10 +185,9 @@ val to_buffer :
   Buffer.t ->
   value ->
   unit res
-(** [to_buffer b v] converts the JSON value to a Yaml representation and
-    writes it to the buffer [b]. The
-    [encoding], [scalar_style] and [layout_style] control the various output
-    parameters. *)
+(** [to_buffer b v] converts the JSON value to a Yaml representation and writes
+    it to the buffer [b]. The [encoding], [scalar_style] and [layout_style]
+    control the various output parameters. *)
 
 val pp : Format.formatter -> value -> unit
 (** [pp ppf s] will output the Yaml value [s] to the formatter [ppf]. *)
@@ -213,8 +210,8 @@ val yaml_to_string :
   string res
 (** [yaml_to_string v] converts the Yaml value to a string representation. The
     [encoding], [scalar_style] and [layout_style] control the various output
-    parameters. If [len] (in bytes) is specified, then a fixed-size buffer
-    is used internally. *)
+    parameters. If [len] (in bytes) is specified, then a fixed-size buffer is
+    used internally. *)
 
 val yaml_to_file_fast :
   ?encoding:encoding ->
@@ -223,9 +220,9 @@ val yaml_to_file_fast :
   unit Ctypes.ptr ->
   yaml ->
   unit res
-(** [yaml_to_file_fast f v] writes the Yaml value to the file [f] given as [FILE*].
-    The [encoding], [scalar_style] and [layout_style] control the various output
-    parameters. *)
+(** [yaml_to_file_fast f v] writes the Yaml value to the file [f] given as
+    [FILE*]. The [encoding], [scalar_style] and [layout_style] control the
+    various output parameters. *)
 
 val yaml_to_channel :
   ?encoding:encoding ->
@@ -342,20 +339,21 @@ module Stream : sig
       output. *)
 
   val emitter : ?len:int -> unit -> emitter res
-  (** [emitter ?len ()] will allocate a new emitter state, which will output a string.
-      If [len] (in bytes) is specified, then a fixed-size buffer is used internally. *)
+  (** [emitter ?len ()] will allocate a new emitter state, which will output a
+      string. If [len] (in bytes) is specified, then a fixed-size buffer is used
+      internally. *)
 
   val emitter_file : unit Ctypes.ptr -> emitter res
-  (** [emitter_file f] will allocate a new emitter state, which will write
-      to the file [f] given as [FILE*]. *)
+  (** [emitter_file f] will allocate a new emitter state, which will write to
+      the file [f] given as [FILE*]. *)
 
-  val emitter_handler: (string -> unit) -> emitter res
+  val emitter_handler : (string -> unit) -> emitter res
   (** [emitter_handler h] will allocate a new emitter state, which will output
       by calling [h] with the written string. *)
 
-  val emitter_buffer: ?buf:Buffer.t -> unit -> emitter res
-  (** [emitter_buffer ~buf ()] will allocate a new emitter state, which will write
-      to the buffer [buf]. If [buf] is not specified, one will be created. *)
+  val emitter_buffer : ?buf:Buffer.t -> unit -> emitter res
+  (** [emitter_buffer ~buf ()] will allocate a new emitter state, which will
+      write to the buffer [buf]. If [buf] is not specified, one will be created. *)
 
   val emitter_buf : emitter -> Bytes.t
   val emitter_string : emitter -> string
@@ -400,10 +398,9 @@ val to_emitter :
   Stream.emitter ->
   value ->
   unit res
-(** [to_emitter e v] converts the JSON value to a Yaml representation and
-    writes it to the emitter [e]. The
-    [encoding], [scalar_style] and [layout_style] control the various output
-    parameters. *)
+(** [to_emitter e v] converts the JSON value to a Yaml representation and writes
+    it to the emitter [e]. The [encoding], [scalar_style] and [layout_style]
+    control the various output parameters. *)
 
 val yaml_to_emitter :
   ?encoding:encoding ->

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -156,11 +156,27 @@ val to_string_exn :
 (** [to_string_exn v] acts as {!to_string}, but raises {!Invalid_argument} in if
     there is an error. *)
 
+val to_file_fast :
+  ?encoding:encoding ->
+  ?scalar_style:scalar_style ->
+  ?layout_style:layout_style ->
+  unit Ctypes.ptr ->
+  value ->
+  unit res
+
 val to_channel :
   ?encoding:encoding ->
   ?scalar_style:scalar_style ->
   ?layout_style:layout_style ->
   out_channel ->
+  value ->
+  unit res
+
+val to_buffer :
+  ?encoding:encoding ->
+  ?scalar_style:scalar_style ->
+  ?layout_style:layout_style ->
+  Buffer.t ->
   value ->
   unit res
 

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -339,9 +339,8 @@ module Stream : sig
       output. *)
 
   val emitter : ?len:int -> unit -> emitter res
-  (** [emitter ?len ()] will allocate a new emitter state, which will output a
-      string. If [len] (in bytes) is specified, then a fixed-size buffer is used
-      internally. *)
+  (** [emitter ?len ()] will allocate a new emitter state, which will write to a
+      fixed-size buffer of size [len] (in bytes). By default the buffer is 64KB. *)
 
   val emitter_file : unit Ctypes.ptr -> emitter res
   (** [emitter_file f] will allocate a new emitter state, which will write to

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -281,7 +281,10 @@ module Stream : sig
 
   val emitter_handler: (string -> unit) -> emitter res
 
+  val emitter_buffer: unit -> emitter res
+
   val emitter_buf : emitter -> Bytes.t
+  val emitter_string : emitter -> string
   val emit : emitter -> Event.t -> unit res
   val document_start : ?version:version -> ?implicit:bool -> emitter -> unit res
   val document_end : ?implicit:bool -> emitter -> unit res

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -279,7 +279,7 @@ module Stream : sig
 
   val emitter_file : unit Ctypes.ptr -> emitter res
 
-  val emitter_handler: (Unsigned.uchar Ctypes_static.ptr -> Unsigned.size_t -> int) -> emitter res
+  val emitter_handler: (string -> unit) -> emitter res
 
   val emitter_buf : emitter -> Bytes.t
   val emit : emitter -> Event.t -> unit res

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -281,7 +281,7 @@ module Stream : sig
 
   val emitter_handler: (string -> unit) -> emitter res
 
-  val emitter_buffer: unit -> emitter res
+  val emitter_buffer: ?buf:Buffer.t -> unit -> emitter res
 
   val emitter_buf : emitter -> Bytes.t
   val emitter_string : emitter -> string

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -143,8 +143,8 @@ val to_string :
   string res
 (** [to_string v] converts the JSON value to a Yaml string representation. The
     [encoding], [scalar_style] and [layout_style] control the various output
-    parameters. The current implementation uses a non-resizable internal string
-    buffer of 64KB, which can be increased via [len]. *)
+    parameters. If [len] (in bytes) is specified, then a fixed-size buffer
+    is used internally. *)
 
 val to_string_exn :
   ?len:int ->
@@ -163,6 +163,10 @@ val to_file_fast :
   unit Ctypes.ptr ->
   value ->
   unit res
+(** [to_file_fast f v] converts the JSON value to a Yaml representation and
+    writes it to the file [f] given as [FILE*]. The
+    [encoding], [scalar_style] and [layout_style] control the various output
+    parameters. *)
 
 val to_channel :
   ?encoding:encoding ->
@@ -171,6 +175,10 @@ val to_channel :
   out_channel ->
   value ->
   unit res
+(** [to_channel oc v] converts the JSON value to a Yaml representation and
+    writes it to the channel [oc]. The
+    [encoding], [scalar_style] and [layout_style] control the various output
+    parameters. *)
 
 val to_buffer :
   ?encoding:encoding ->
@@ -179,6 +187,10 @@ val to_buffer :
   Buffer.t ->
   value ->
   unit res
+(** [to_buffer b v] converts the JSON value to a Yaml representation and
+    writes it to the buffer [b]. The
+    [encoding], [scalar_style] and [layout_style] control the various output
+    parameters. *)
 
 val pp : Format.formatter -> value -> unit
 (** [pp ppf s] will output the Yaml value [s] to the formatter [ppf]. *)
@@ -201,8 +213,8 @@ val yaml_to_string :
   string res
 (** [yaml_to_string v] converts the Yaml value to a string representation. The
     [encoding], [scalar_style] and [layout_style] control the various output
-    parameters. The current implementation uses a non-resizable internal string
-    buffer of 16KB, which can be increased via [len]. *)
+    parameters. If [len] (in bytes) is specified, then a fixed-size buffer
+    is used internally. *)
 
 val yaml_to_file_fast :
   ?encoding:encoding ->
@@ -211,6 +223,9 @@ val yaml_to_file_fast :
   unit Ctypes.ptr ->
   yaml ->
   unit res
+(** [yaml_to_file_fast f v] writes the Yaml value to the file [f] given as [FILE*].
+    The [encoding], [scalar_style] and [layout_style] control the various output
+    parameters. *)
 
 val yaml_to_channel :
   ?encoding:encoding ->
@@ -219,6 +234,9 @@ val yaml_to_channel :
   out_channel ->
   yaml ->
   unit res
+(** [yaml_to_channel oc v] writes the Yaml value to the channel [oc]. The
+    [encoding], [scalar_style] and [layout_style] control the various output
+    parameters. *)
 
 val yaml_to_buffer :
   ?encoding:encoding ->
@@ -227,6 +245,9 @@ val yaml_to_buffer :
   Buffer.t ->
   yaml ->
   unit res
+(** [yaml_to_buffer b v] writes the Yaml value to the buffer [b]. The
+    [encoding], [scalar_style] and [layout_style] control the various output
+    parameters. *)
 
 (** {2 JSON/Yaml conversion functions} *)
 
@@ -321,16 +342,20 @@ module Stream : sig
       output. *)
 
   val emitter : ?len:int -> unit -> emitter res
-  (** [emitter ?len ()] will allocate a new emitter state. Due to a temporary
-      limitation in the implementation, [len] decides how large the fixed size
-      buffer that the output is written into is. In the future, [len] will be
-      redundant as the buffer will be dynamically allocated. *)
+  (** [emitter ?len ()] will allocate a new emitter state, which will output a string.
+      If [len] (in bytes) is specified, then a fixed-size buffer is used internally. *)
 
   val emitter_file : unit Ctypes.ptr -> emitter res
+  (** [emitter_file f] will allocate a new emitter state, which will write
+      to the file [f] given as [FILE*]. *)
 
   val emitter_handler: (string -> unit) -> emitter res
+  (** [emitter_handler h] will allocate a new emitter state, which will output
+      by calling [h] with the written string. *)
 
   val emitter_buffer: ?buf:Buffer.t -> unit -> emitter res
+  (** [emitter_buffer ~buf ()] will allocate a new emitter state, which will write
+      to the buffer [buf]. If [buf] is not specified, one will be created. *)
 
   val emitter_buf : emitter -> Bytes.t
   val emitter_string : emitter -> string
@@ -375,6 +400,10 @@ val to_emitter :
   Stream.emitter ->
   value ->
   unit res
+(** [to_emitter e v] converts the JSON value to a Yaml representation and
+    writes it to the emitter [e]. The
+    [encoding], [scalar_style] and [layout_style] control the various output
+    parameters. *)
 
 val yaml_to_emitter :
   ?encoding:encoding ->
@@ -383,6 +412,9 @@ val yaml_to_emitter :
   Stream.emitter ->
   yaml ->
   unit res
+(** [yaml_to_emitter e v] writes the Yaml value to the emitter [e]. The
+    [encoding], [scalar_style] and [layout_style] control the various output
+    parameters. *)
 
 (** {2 Utility functions for yaml}
 

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -193,6 +193,7 @@ val yaml_of_string : string -> yaml res
     Yaml-specific information such as anchors. *)
 
 val yaml_to_string :
+  ?len:int ->
   ?encoding:encoding ->
   ?scalar_style:scalar_style ->
   ?layout_style:layout_style ->
@@ -202,6 +203,30 @@ val yaml_to_string :
     [encoding], [scalar_style] and [layout_style] control the various output
     parameters. The current implementation uses a non-resizable internal string
     buffer of 16KB, which can be increased via [len]. *)
+
+val yaml_to_file_fast :
+  ?encoding:encoding ->
+  ?scalar_style:scalar_style ->
+  ?layout_style:layout_style ->
+  unit Ctypes.ptr ->
+  yaml ->
+  unit res
+
+val yaml_to_channel :
+  ?encoding:encoding ->
+  ?scalar_style:scalar_style ->
+  ?layout_style:layout_style ->
+  out_channel ->
+  yaml ->
+  unit res
+
+val yaml_to_buffer :
+  ?encoding:encoding ->
+  ?scalar_style:scalar_style ->
+  ?layout_style:layout_style ->
+  Buffer.t ->
+  yaml ->
+  unit res
 
 (** {2 JSON/Yaml conversion functions} *)
 
@@ -349,6 +374,14 @@ val to_emitter :
   ?layout_style:layout_style ->
   Stream.emitter ->
   value ->
+  unit res
+
+val yaml_to_emitter :
+  ?encoding:encoding ->
+  ?scalar_style:scalar_style ->
+  ?layout_style:layout_style ->
+  Stream.emitter ->
+  yaml ->
   unit res
 
 (** {2 Utility functions for yaml}

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -279,6 +279,8 @@ module Stream : sig
 
   val emitter_file : unit Ctypes.ptr -> emitter res
 
+  val emitter_handler: (Unsigned.uchar Ctypes_static.ptr -> Unsigned.size_t -> int) -> emitter res
+
   val emitter_buf : emitter -> Bytes.t
   val emit : emitter -> Event.t -> unit res
   val document_start : ?version:version -> ?implicit:bool -> emitter -> unit res

--- a/types/bindings/dune
+++ b/types/bindings/dune
@@ -1,4 +1,4 @@
 (library
  (name yaml_bindings_types)
  (public_name yaml.bindings.types)
- (libraries ctypes.stubs ctypes))
+ (libraries ctypes.stubs ctypes ctypes.foreign))

--- a/unix/dune
+++ b/unix/dune
@@ -1,4 +1,4 @@
 (library
  (name yaml_unix)
  (public_name yaml.unix)
- (libraries yaml bos))
+ (libraries yaml bos ctypes.foreign))

--- a/unix/yaml_unix.ml
+++ b/unix/yaml_unix.ml
@@ -15,18 +15,24 @@
 open Bos
 
 let ( >>= ) = Result.bind
-
 let of_file f = Result.bind (OS.File.read f) Yaml.of_string
-let to_file ?encoding ?scalar_style ?layout_style f y = OS.File.with_oc f (Yaml.to_channel ?encoding ?scalar_style ?layout_style) y |> Result.join
+
+let to_file ?encoding ?scalar_style ?layout_style f y =
+  OS.File.with_oc f (Yaml.to_channel ?encoding ?scalar_style ?layout_style) y
+  |> Result.join
 
 let of_file_exn f =
   match of_file f with Ok v -> v | Error (`Msg m) -> raise (Failure m)
 
 let to_file_exn ?encoding ?scalar_style ?layout_style f v =
-  match to_file ?encoding ?scalar_style ?layout_style f v with Ok () -> () | Error (`Msg m) -> raise (Failure m)
+  match to_file ?encoding ?scalar_style ?layout_style f v with
+  | Ok () -> ()
+  | Error (`Msg m) -> raise (Failure m)
 
 (* TODO: stubs not foreign *)
-let c_fopen = Ctypes.(Foreign.foreign "fopen" (string @-> string @-> returning (ptr void)))
+let c_fopen =
+  Ctypes.(Foreign.foreign "fopen" (string @-> string @-> returning (ptr void)))
+
 let c_fclose = Ctypes.(Foreign.foreign "fclose" (ptr void @-> returning int))
 
 let to_file_fast ?encoding ?scalar_style ?layout_style f y =

--- a/unix/yaml_unix.ml
+++ b/unix/yaml_unix.ml
@@ -16,12 +16,8 @@ open Bos
 
 let ( >>= ) = Result.bind
 
-let to_channel ?(encoding = `Utf8) ?scalar_style ?layout_style oc (v : Yaml.value) =
-  Yaml.Stream.emitter_handler (output_string oc) >>= fun t ->
-  Yaml.to_emitter ~encoding ?scalar_style ?layout_style t v
-
 let of_file f = Result.bind (OS.File.read f) Yaml.of_string
-let to_file f y = OS.File.with_oc f to_channel y |> Result.join
+let to_file f y = OS.File.with_oc f Yaml.to_channel y |> Result.join
 
 let of_file_exn f =
   match of_file f with Ok v -> v | Error (`Msg m) -> raise (Failure m)

--- a/unix/yaml_unix.ml
+++ b/unix/yaml_unix.ml
@@ -16,9 +16,6 @@ open Bos
 
 let ( >>= ) = Result.bind
 
-(* TODO: stubs not foreign *)
-let fdopen = Ctypes.(Foreign.foreign "fdopen" (int @-> string @-> returning (ptr void)))
-
 let to_channel ?(encoding = `Utf8) ?scalar_style ?layout_style oc (v : Yaml.value) =
   Yaml.Stream.emitter_handler (output_string oc) >>= fun t ->
   Yaml.to_emitter ~encoding ?scalar_style ?layout_style t v

--- a/unix/yaml_unix.ml
+++ b/unix/yaml_unix.ml
@@ -20,13 +20,7 @@ let ( >>= ) = Result.bind
 let fdopen = Ctypes.(Foreign.foreign "fdopen" (int @-> string @-> returning (ptr void)))
 
 let to_channel ?(encoding = `Utf8) ?scalar_style ?layout_style oc (v : Yaml.value) =
-  let handler buf len =
-    let buf' = Ctypes.(coerce (ptr uchar) (ptr char) buf) in
-    let s = Ctypes.(string_from_ptr buf' ~length:(Unsigned.Size_t.to_int len)) in
-    output_string oc s;
-    1
-  in
-  Yaml.Stream.emitter_handler handler >>= fun t ->
+  Yaml.Stream.emitter_handler (output_string oc) >>= fun t ->
   Yaml.to_emitter ~encoding ?scalar_style ?layout_style t v
 
 let of_file f = Result.bind (OS.File.read f) Yaml.of_string

--- a/unix/yaml_unix.ml
+++ b/unix/yaml_unix.ml
@@ -24,3 +24,14 @@ let of_file_exn f =
 
 let to_file_exn f v =
   match to_file f v with Ok () -> () | Error (`Msg m) -> raise (Failure m)
+
+(* TODO: stubs not foreign *)
+let c_fopen = Ctypes.(Foreign.foreign "fopen" (string @-> string @-> returning (ptr void)))
+let c_fclose = Ctypes.(Foreign.foreign "fclose" (ptr void @-> returning int))
+
+let to_file_fast f y =
+  (* TODO: error handling *)
+  let file = c_fopen (Fpath.to_string f) "w" in
+  Yaml.to_file_fast file y >>= fun () ->
+  ignore (c_fclose file);
+  Ok ()

--- a/unix/yaml_unix.ml
+++ b/unix/yaml_unix.ml
@@ -17,21 +17,21 @@ open Bos
 let ( >>= ) = Result.bind
 
 let of_file f = Result.bind (OS.File.read f) Yaml.of_string
-let to_file f y = OS.File.with_oc f Yaml.to_channel y |> Result.join
+let to_file ?encoding ?scalar_style ?layout_style f y = OS.File.with_oc f (Yaml.to_channel ?encoding ?scalar_style ?layout_style) y |> Result.join
 
 let of_file_exn f =
   match of_file f with Ok v -> v | Error (`Msg m) -> raise (Failure m)
 
-let to_file_exn f v =
-  match to_file f v with Ok () -> () | Error (`Msg m) -> raise (Failure m)
+let to_file_exn ?encoding ?scalar_style ?layout_style f v =
+  match to_file ?encoding ?scalar_style ?layout_style f v with Ok () -> () | Error (`Msg m) -> raise (Failure m)
 
 (* TODO: stubs not foreign *)
 let c_fopen = Ctypes.(Foreign.foreign "fopen" (string @-> string @-> returning (ptr void)))
 let c_fclose = Ctypes.(Foreign.foreign "fclose" (ptr void @-> returning int))
 
-let to_file_fast f y =
+let to_file_fast ?encoding ?scalar_style ?layout_style f y =
   (* TODO: error handling *)
   let file = c_fopen (Fpath.to_string f) "w" in
-  Yaml.to_file_fast file y >>= fun () ->
+  Yaml.to_file_fast ?encoding ?scalar_style ?layout_style file y >>= fun () ->
   ignore (c_fclose file);
   Ok ()

--- a/unix/yaml_unix.mli
+++ b/unix/yaml_unix.mli
@@ -29,8 +29,9 @@ val to_file :
   Fpath.t ->
   Yaml.value ->
   unit Yaml.res
-(** [to_file p v] will convert the Yaml value [v] to a string and write it to
-    the file at path [p]. *)
+(** [to_file p v] will convert the Yaml value [v] to a Yaml representation
+    and write it to the file at path [p]. The [encoding], [scalar_style] and [layout_style]
+    control the various output parameters. *)
 
 val to_file_exn :
   ?encoding:Yaml.encoding ->
@@ -49,3 +50,7 @@ val to_file_fast :
   Fpath.t ->
   Yaml.value ->
   unit Yaml.res
+(** [to_file_fast p v] will convert the Yaml value [v] to a Yaml representation
+    and write it to the file at path [p]. The [encoding], [scalar_style] and [layout_style]
+    control the various output parameters.
+    Unlike {!to_file}, this function writes the file directly in libyaml instead of going through OCaml. *)

--- a/unix/yaml_unix.mli
+++ b/unix/yaml_unix.mli
@@ -22,6 +22,10 @@ val of_file_exn : Fpath.t -> Yaml.value
 (** [of_file_exn p] acts as {!of_file}, but errors are thrown as a {!Failure}
     exception instead of in the return value. *)
 
+val to_channel : ?encoding:Yaml.encoding ->
+    ?scalar_style:Yaml.scalar_style ->
+    ?layout_style:Yaml.layout_style -> out_channel -> Yaml.value -> (unit, [ `Msg of string ]) result
+
 val to_file : Fpath.t -> Yaml.value -> (unit, [ `Msg of string ]) result
 (** [to_file p v] will convert the Yaml value [v] to a string and write it to
     the file at path [p]. *)

--- a/unix/yaml_unix.mli
+++ b/unix/yaml_unix.mli
@@ -22,12 +22,30 @@ val of_file_exn : Fpath.t -> Yaml.value
 (** [of_file_exn p] acts as {!of_file}, but errors are thrown as a {!Failure}
     exception instead of in the return value. *)
 
-val to_file : Fpath.t -> Yaml.value -> (unit, [ `Msg of string ]) result
+val to_file :
+  ?encoding:Yaml.encoding ->
+  ?scalar_style:Yaml.scalar_style ->
+  ?layout_style:Yaml.layout_style ->
+  Fpath.t ->
+  Yaml.value ->
+  unit Yaml.res
 (** [to_file p v] will convert the Yaml value [v] to a string and write it to
     the file at path [p]. *)
 
-val to_file_exn : Fpath.t -> Yaml.value -> unit
+val to_file_exn :
+  ?encoding:Yaml.encoding ->
+  ?scalar_style:Yaml.scalar_style ->
+  ?layout_style:Yaml.layout_style ->
+  Fpath.t ->
+  Yaml.value ->
+  unit
 (** [to_file_exn p] acts as {!to_file}, but errors are thrown as a {!Failure}
     exception instead of in the return value. *)
 
-val to_file_fast : Fpath.t -> Yaml.value -> (unit, [ `Msg of string ]) result
+val to_file_fast :
+  ?encoding:Yaml.encoding ->
+  ?scalar_style:Yaml.scalar_style ->
+  ?layout_style:Yaml.layout_style ->
+  Fpath.t ->
+  Yaml.value ->
+  unit Yaml.res

--- a/unix/yaml_unix.mli
+++ b/unix/yaml_unix.mli
@@ -29,9 +29,9 @@ val to_file :
   Fpath.t ->
   Yaml.value ->
   unit Yaml.res
-(** [to_file p v] will convert the Yaml value [v] to a Yaml representation
-    and write it to the file at path [p]. The [encoding], [scalar_style] and [layout_style]
-    control the various output parameters. *)
+(** [to_file p v] will convert the Yaml value [v] to a Yaml representation and
+    write it to the file at path [p]. The [encoding], [scalar_style] and
+    [layout_style] control the various output parameters. *)
 
 val to_file_exn :
   ?encoding:Yaml.encoding ->
@@ -51,6 +51,7 @@ val to_file_fast :
   Yaml.value ->
   unit Yaml.res
 (** [to_file_fast p v] will convert the Yaml value [v] to a Yaml representation
-    and write it to the file at path [p]. The [encoding], [scalar_style] and [layout_style]
-    control the various output parameters.
-    Unlike {!to_file}, this function writes the file directly in libyaml instead of going through OCaml. *)
+    and write it to the file at path [p]. The [encoding], [scalar_style] and
+    [layout_style] control the various output parameters. Unlike {!to_file},
+    this function writes the file directly in libyaml instead of going through
+    OCaml. *)

--- a/unix/yaml_unix.mli
+++ b/unix/yaml_unix.mli
@@ -22,10 +22,6 @@ val of_file_exn : Fpath.t -> Yaml.value
 (** [of_file_exn p] acts as {!of_file}, but errors are thrown as a {!Failure}
     exception instead of in the return value. *)
 
-val to_channel : ?encoding:Yaml.encoding ->
-    ?scalar_style:Yaml.scalar_style ->
-    ?layout_style:Yaml.layout_style -> out_channel -> Yaml.value -> (unit, [ `Msg of string ]) result
-
 val to_file : Fpath.t -> Yaml.value -> (unit, [ `Msg of string ]) result
 (** [to_file p v] will convert the Yaml value [v] to a string and write it to
     the file at path [p]. *)

--- a/unix/yaml_unix.mli
+++ b/unix/yaml_unix.mli
@@ -29,3 +29,5 @@ val to_file : Fpath.t -> Yaml.value -> (unit, [ `Msg of string ]) result
 val to_file_exn : Fpath.t -> Yaml.value -> unit
 (** [to_file_exn p] acts as {!to_file}, but errors are thrown as a {!Failure}
     exception instead of in the return value. *)
+
+val to_file_fast : Fpath.t -> Yaml.value -> (unit, [ `Msg of string ]) result

--- a/yaml.opam
+++ b/yaml.opam
@@ -26,6 +26,7 @@ depends: [
   "dune" {>= "2.0"}
   "dune-configurator"
   "ctypes" {>= "0.14.0"}
+  "ctypes-foreign"
   "bos"
   "fmt" {with-test}
   "logs" {with-test}


### PR DESCRIPTION
This is a continuation and improvement of #61.

### Changes
1. Instead of trying to get `FILE*` from OCaml's `out_channel` (which causes double-opened descriptors), I just fall back to `fopen` here.
2. Add support for generic `write_handler`s.
3. Using the above, add support for output to dynamically-sized `Buffer.t`. 
4. Using the above, remove the default `len` limit from `to_string` (which the documentation has promised to do in the _future_).
5. Allow `?encoding ?scalar_style ?layout_style` arguments on all output functions.

### TODO
- [ ] `yaml_emitter_set_output_file` takes `FILE*` argument for which I currently use `ptr void`, is there anything better?
- [ ] Ideally `Stream.emitter` type would be a GADT, which distinguishes the kind of output it was created for (and thus statically prevent some buffer-specific functions from being called on it). A GADT would be a breaking interface change, so maybe just a runtime exception for misuse is good enough?
- [ ] ctypes-foreign is used to pass OCaml functions for emitter `write_handler`s, I suppose that's inevitable?
- [ ] ctypes-foreign is used to call `fopen`/`fclose` to get a `FILE*` (really `ptr void`) to give to libyaml. Should probably use ctypes stubs for it instead, but it'd be much easier after #41.
- [ ] To be symmetric, a similar optimization could be done to `of_file`, I suppose, but it's less critical since that doesn't have a fixed-buffer limitation. (And I got stuck trying to define `read_handler`s with ctypes, so I left it out right now.) 