### PR TITLE
Fix GitHub Actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [macos-latest, ubuntu-latest, windows-latest]
-        ocaml-compiler: [ '4.12.0', '4.10.2', '4.06.2', '4.05.1']
+        ocaml-compiler: [ '4.12.x', '4.10.x', '4.06.x', '4.05.x']
     steps:
     - uses: actions/checkout@master
     - uses: ocaml/setup-ocaml@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         operating-system: [macos-latest, ubuntu-latest, windows-latest]
-        ocaml-compiler: [ '4.12.x', '4.10.x', '4.06.x', '4.05.x']
+        ocaml-compiler: ['4.14.x', '4.13.x']
     steps:
     - uses: actions/checkout@master
     - uses: ocaml/setup-ocaml@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: ocaml/setup-ocaml@v2
       with:
-        ocaml-version: ${{ matrix.ocaml-version }}
+        ocaml-compiler: ${{ matrix.ocaml-compiler }}
     - run: opam pin add yaml.dev -n .
     - run: opam pin add yaml-sexp.dev -n .
     - name: Packages


### PR DESCRIPTION
This fixes a surprising number of problems:
1. In https://github.com/avsm/ocaml-yaml/commit/3c1d012cd50dd4348aa4d631a49f9ae8cc299b44, the matrix was updated to define `ocaml-compiler`, but the setup-ocaml@v2 input still was named `ocaml-version`, which emitted a warning, but quietly used the latest OCaml version instead of the desired one. So the matrix was useless since then!
2. After fixing that, it turned out that 4.05.1 and 4.06.2 cannot even be installed with the action, because the "ocaml" packages with those versions don't have corresponding "ocaml-base-compiler" versions.
3. After fixing that, it was apparent that all the listed versions are below the current ocaml lower bound of this package, which is further proof that the GitHub Actions workflow wasn't actually testing these versions.