### PR TITLE
Bugfix: emitter buffer could move under its feet because of GC

### DIFF
--- a/ffi/bindings/yaml_bindings.ml
+++ b/ffi/bindings/yaml_bindings.ml
@@ -57,7 +57,7 @@ module M (F : Ctypes.FOREIGN) = struct
     foreign "yaml_emitter_set_output_string"
       C.(
         ptr T.Emitter.t
-        @-> ocaml_bytes
+        @-> ptr char
         @-> size_t
         @-> ptr size_t
         @-> returning void)

--- a/lib/yaml.ml
+++ b/lib/yaml.ml
@@ -115,7 +115,7 @@ let to_string ?len ?(encoding = `Utf8) ?scalar_style ?layout_style (v : value) =
   document_end t >>= fun () ->
   stream_end t >>= fun () ->
   let r = Stream.emitter_buf t in
-  Ok (Bytes.to_string r)
+  Ok r
 
 let to_string_exn ?len ?encoding ?scalar_style ?layout_style s =
   match to_string ?len ?encoding ?scalar_style ?layout_style s with
@@ -151,7 +151,7 @@ let yaml_to_string ?len ?(encoding = `Utf8) ?scalar_style ?layout_style v =
   document_end t >>= fun () ->
   stream_end t >>= fun () ->
   let r = Stream.emitter_buf t in
-  Ok (Bytes.to_string r)
+  Ok r
 
 let yaml_of_string s =
   let open Event in

--- a/lib/yaml.ml
+++ b/lib/yaml.ml
@@ -122,8 +122,8 @@ let to_string_exn ?len ?encoding ?scalar_style ?layout_style s =
   | Ok s -> s
   | Error (`Msg m) -> raise (Invalid_argument m)
 
-let yaml_to_string ?(encoding = `Utf8) ?scalar_style ?layout_style v =
-  emitter () >>= fun t ->
+let yaml_to_string ?len ?(encoding = `Utf8) ?scalar_style ?layout_style v =
+  emitter ?len () >>= fun t ->
   stream_start t encoding >>= fun () ->
   document_start t >>= fun () ->
   let rec iter = function

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -278,7 +278,7 @@ module Stream : sig
       buffer that the output is written into is. In the future, [len] will be
       redundant as the buffer will be dynamically allocated. *)
 
-  val emitter_buf : emitter -> Bytes.t
+  val emitter_buf : emitter -> string
   val emit : emitter -> Event.t -> unit res
   val document_start : ?version:version -> ?implicit:bool -> emitter -> unit res
   val document_end : ?implicit:bool -> emitter -> unit res

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -144,7 +144,7 @@ val to_string :
 (** [to_string v] converts the JSON value to a Yaml string representation. The
     [encoding], [scalar_style] and [layout_style] control the various output
     parameters. The current implementation uses a non-resizable internal string
-    buffer of 64KB, which can be increased via [len]. *)
+    buffer of 256KB, which can be increased via [len]. *)
 
 val to_string_exn :
   ?len:int ->
@@ -178,7 +178,7 @@ val yaml_to_string :
 (** [yaml_to_string v] converts the Yaml value to a string representation. The
     [encoding], [scalar_style] and [layout_style] control the various output
     parameters. The current implementation uses a non-resizable internal string
-    buffer of 16KB, which can be increased via [len]. *)
+    buffer of 256KB, which can be increased via [len]. *)
 
 (** {2 JSON/Yaml conversion functions} *)
 

--- a/lib/yaml.mli
+++ b/lib/yaml.mli
@@ -169,6 +169,7 @@ val yaml_of_string : string -> yaml res
     Yaml-specific information such as anchors. *)
 
 val yaml_to_string :
+  ?len:int ->
   ?encoding:encoding ->
   ?scalar_style:scalar_style ->
   ?layout_style:layout_style ->

--- a/tests/test_emit.ml
+++ b/tests/test_emit.ml
@@ -43,5 +43,5 @@ let v () =
   S.stream_end t >>= fun () ->
   Printf.printf "written: %d\n%!" (S.emitter_written t);
   let r = S.emitter_buf t in
-  print_endline (Bytes.to_string r);
+  print_endline r;
   Ok ()

--- a/tests/test_reflect.ml
+++ b/tests/test_reflect.ml
@@ -31,5 +31,5 @@ let v file =
   iter_until_done (reflect e) >>= fun () ->
   let r = Yaml.Stream.emitter_buf e in
   print_endline buf;
-  print_endline (Bytes.to_string r);
+  print_endline r;
   Ok ()


### PR DESCRIPTION
On top of #74 

probably fix #71 

Similar to https://github.com/avsm/ocaml-yaml/pull/35