### PR TITLE
Serialization no longer uses a fixed size buffer.

### DIFF
--- a/ffi/bindings/dune
+++ b/ffi/bindings/dune
@@ -2,4 +2,4 @@
  (name yaml_bindings)
  (synopsis "Ctypes bindings that describe the libyaml FFI")
  (public_name yaml.bindings)
- (libraries yaml.types ctypes.stubs ctypes))
+ (libraries yaml.types ctypes.stubs ctypes ctypes.foreign))

--- a/ffi/bindings/yaml_bindings.ml
+++ b/ffi/bindings/yaml_bindings.ml
@@ -14,6 +14,9 @@
 
 module T = Yaml_types.M
 
+
+let write_handler = let open Ctypes in (ptr void @-> ptr uchar @-> size_t @-> returning int)
+
 module M (F : Ctypes.FOREIGN) = struct
   let foreign = F.foreign
 
@@ -62,12 +65,14 @@ module M (F : Ctypes.FOREIGN) = struct
         @-> ptr size_t
         @-> returning void)
 
-  (* TODO static funptr
-     let write_handler = C.(ptr void @-> ptr uchar @-> size_t @-> returning int)
 
-     let emitter_set_output =
-       foreign "yaml_emitter_set_output" C.(ptr T.Emitter.t @-> (static_funptr write_handler) @-> ptr void @-> returning void)
-  *)
+  let emitter_set_output =
+    foreign "yaml_emitter_set_output"
+      C.(
+        ptr T.Emitter.t
+        @-> (Foreign.funptr write_handler)
+        @-> ptr void
+        @-> returning void)
 
   let emitter_set_encoding =
     foreign "yaml_emitter_set_encoding"

--- a/types/bindings/yaml_bindings_types.ml
+++ b/types/bindings/yaml_bindings_types.ml
@@ -416,6 +416,8 @@ module M (F : Ctypes.TYPE) = struct
     type t
 
     let t : t typ = F.structure "yaml_emitter_s"
+    let error = F.(field t "error" error_t)
+    let problem = F.(field t "problem" string_opt)
 
     (* TODO *)
     let () = F.seal t


### PR DESCRIPTION
This is still WIP has I'm not sure we want the dependency on `ctypes.foreign`