### PR TITLE
Fix memory leaks

### DIFF
--- a/ffi/bindings/yaml_bindings.ml
+++ b/ffi/bindings/yaml_bindings.ml
@@ -33,6 +33,9 @@ module M (F : Ctypes.FOREIGN) = struct
   let token_delete =
     foreign "yaml_token_delete" C.(ptr T.Token.t @-> returning void)
 
+  let event_delete =
+    foreign "yaml_event_delete" C.(ptr T.Event.t @-> returning void)
+
   let parser_init =
     foreign "yaml_parser_initialize" C.(ptr T.Parser.t @-> returning int)
 


### PR DESCRIPTION
## Description
Fixes memory leaks due to certain structures not being deallocated correctly.

From `yaml.h`:
```c
...
 * An application is responsible for freeing any buffers associated with the
 * produced event object using the yaml_event_delete() function.
...
```

The caller is responsible for calling the corresponding `*_delete` functions on returned C structures (e.g. on `yaml_parser_t`, `yaml_parser_delete` must be called) since they internally refer to other heap-allocated structures.

## Reproduction
Reproduction steps are based on steps given in https://github.com/avsm/ocaml-yaml/issues/73:

Using the YAML file `tests/yaml/too_large.yml` as an argument, with `main.ml`:
```ocaml
let file_contents path =
  let input = open_in path in
  Fun.protect ~finally: (fun () -> close_in input) @@ fun () ->
    really_input_string input (in_channel_length input)

let process_yaml path =
  path
  |> file_contents
  |> Yaml.of_string_exn

let () =
  let processed_yaml = process_yaml Sys.argv.(1) in
  print_string (Yaml.to_string_exn processed_yaml);
  Gc.full_major ()
```

**Before Fix**
```
==119636== LEAK SUMMARY:
==119636==    definitely lost: 132,434 bytes in 217 blocks
==119636==    indirectly lost: 26 bytes in 4 blocks
==119636==      possibly lost: 0 bytes in 0 blocks
==119636==    still reachable: 1,501,707 bytes in 291 blocks
==119636==         suppressed: 0 bytes in 0 blocks
```

**After Fix**
```
==119064== LEAK SUMMARY:
==119064==    definitely lost: 0 bytes in 0 blocks
==119064==    indirectly lost: 0 bytes in 0 blocks
==119064==      possibly lost: 0 bytes in 0 blocks
==119064==    still reachable: 1,490,923 bytes in 121 blocks
==119064==         suppressed: 0 bytes in 0 blocks
```


Fixes https://github.com/avsm/ocaml-yaml/issues/73 